### PR TITLE
Add CI to `main` branch on push

### DIFF
--- a/.github/workflows/full_ci.yaml
+++ b/.github/workflows/full_ci.yaml
@@ -4,6 +4,8 @@ on:
   merge_group:
   pull_request:
     types: [opened, synchronize, reopened]
+  push:
+    branches: [ "main" ]
 
 jobs:
   style_check:


### PR DESCRIPTION
Adds CI tests to run on the main branch once a change has been pushed.