### PR TITLE
Refactor `to_bytes()` to use `PacketWriter`

### DIFF
--- a/pkts-common/src/lib.rs
+++ b/pkts-common/src/lib.rs
@@ -10,7 +10,8 @@
 
 #![forbid(unsafe_code)]
 
-use core::array;
+use std::array;
+use std::ops::{Index, Range, RangeFrom, RangeInclusive, RangeTo, RangeToInclusive};
 
 #[derive(Clone, Debug)]
 pub struct Buffer<T: Copy, const N: usize> {
@@ -23,7 +24,9 @@ impl<T: Copy + Default, const N: usize> Buffer<T, N> {
     pub fn new() -> Self {
         Self::default()
     }
+}
 
+impl<T: Copy, const N: usize> Buffer<T, N> {
     #[inline]
     pub fn as_slice(&self) -> &[T] {
         &self.buf[..self.buf_len]
@@ -78,6 +81,60 @@ impl<T: Copy + Default, const N: usize> Default for Buffer<T, N> {
             buf: array::from_fn(|_| T::default()),
             buf_len: 0,
         }
+    }
+}
+
+impl<T: Copy, const N: usize> Index<usize> for Buffer<T, N> {
+    type Output = T;
+
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        self.as_slice().index(index)
+    }
+}
+
+impl<T: Copy, const N: usize> Index<Range<usize>> for Buffer<T, N> {
+    type Output = [T];
+
+    #[inline]
+    fn index(&self, index: Range<usize>) -> &Self::Output {
+        self.as_slice().index(index)
+    }
+}
+
+impl<T: Copy, const N: usize> Index<RangeFrom<usize>> for Buffer<T, N> {
+    type Output = [T];
+
+    #[inline]
+    fn index(&self, index: RangeFrom<usize>) -> &Self::Output {
+        self.as_slice().index(index)
+    }
+}
+
+impl<T: Copy, const N: usize> Index<RangeInclusive<usize>> for Buffer<T, N> {
+    type Output = [T];
+
+    #[inline]
+    fn index(&self, index: RangeInclusive<usize>) -> &Self::Output {
+        self.as_slice().index(index)
+    }
+}
+
+impl<T: Copy, const N: usize> Index<RangeTo<usize>> for Buffer<T, N> {
+    type Output = [T];
+
+    #[inline]
+    fn index(&self, index: RangeTo<usize>) -> &Self::Output {
+        self.as_slice().index(index)
+    }
+}
+
+impl<T: Copy, const N: usize> Index<RangeToInclusive<usize>> for Buffer<T, N> {
+    type Output = [T];
+
+    #[inline]
+    fn index(&self, index: RangeToInclusive<usize>) -> &Self::Output {
+        self.as_slice().index(index)
     }
 }
 
@@ -165,5 +222,59 @@ impl<'a> BufferMut<'a> {
     #[inline]
     pub fn remaining(&self) -> usize {
         self.buf.len() - self.buf_len
+    }
+}
+
+impl Index<usize> for BufferMut<'_> {
+    type Output = u8;
+
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        self.as_slice().index(index)
+    }
+}
+
+impl Index<Range<usize>> for BufferMut<'_> {
+    type Output = [u8];
+
+    #[inline]
+    fn index(&self, index: Range<usize>) -> &Self::Output {
+        self.as_slice().index(index)
+    }
+}
+
+impl Index<RangeFrom<usize>> for BufferMut<'_> {
+    type Output = [u8];
+
+    #[inline]
+    fn index(&self, index: RangeFrom<usize>) -> &Self::Output {
+        self.as_slice().index(index)
+    }
+}
+
+impl Index<RangeInclusive<usize>> for BufferMut<'_> {
+    type Output = [u8];
+
+    #[inline]
+    fn index(&self, index: RangeInclusive<usize>) -> &Self::Output {
+        self.as_slice().index(index)
+    }
+}
+
+impl Index<RangeTo<usize>> for BufferMut<'_> {
+    type Output = [u8];
+
+    #[inline]
+    fn index(&self, index: RangeTo<usize>) -> &Self::Output {
+        self.as_slice().index(index)
+    }
+}
+
+impl Index<RangeToInclusive<usize>> for BufferMut<'_> {
+    type Output = [u8];
+
+    #[inline]
+    fn index(&self, index: RangeToInclusive<usize>) -> &Self::Output {
+        self.as_slice().index(index)
     }
 }

--- a/pkts/src/dev_prelude.rs
+++ b/pkts/src/dev_prelude.rs
@@ -1,0 +1,5 @@
+pub use crate::prelude::*;
+
+pub use crate::writer::{IndexedWriteError, PacketWritable, PacketWriter};
+
+pub use crate::layers::dev_traits::*;

--- a/pkts/src/error.rs
+++ b/pkts/src/error.rs
@@ -77,6 +77,14 @@ impl SerializationError {
         }
     }
 
+    #[inline]
+    pub(crate) fn internal(layer: &'static str) -> Self {
+        SerializationError {
+            class: SerializationErrorClass::Internal,
+            layer,
+        }
+    }
+
     pub fn class(&self) -> SerializationErrorClass {
         self.class
     }
@@ -99,4 +107,6 @@ pub enum SerializationErrorClass {
     /// [`Ipv6`]: struct@crate::layers::ip::Ipv6
     /// [`Tcp`]: struct@crate::layers::tcp::Tcp
     BadUpperLayer,
+    /// An unexpected error occurred internally while encoding.
+    Internal,
 }

--- a/pkts/src/layers.rs
+++ b/pkts/src/layers.rs
@@ -46,6 +46,7 @@ use core::fmt::Debug;
 use crate::error::*;
 use crate::layers::dev_traits::*;
 use crate::layers::traits::*;
+use crate::writer::PacketWriter;
 
 use pkts_macros::{Layer, LayerRef, StatelessLayer};
 
@@ -128,10 +129,11 @@ impl LayerObject for Raw {
 impl ToBytes for Raw {
     fn to_bytes_checksummed(
         &self,
-        bytes: &mut Vec<u8>,
+        writer: &mut PacketWriter<'_, Vec<u8>>,
         _prev: Option<(LayerId, usize)>,
     ) -> Result<(), SerializationError> {
-        bytes.extend(&self.data);
+        writer.update_layer::<Raw>();
+        writer.write_slice(&self.data)?;
         Ok(())
     }
 }

--- a/pkts/src/layers/example.rs
+++ b/pkts/src/layers/example.rs
@@ -13,6 +13,7 @@ use pkts_macros::{Layer, LayerRef, StatelessLayer};
 use crate::error::*;
 use crate::layers::dev_traits::*;
 use crate::layers::traits::*;
+use crate::writer::PacketWriter;
 
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 use alloc::boxed::Box;
@@ -73,9 +74,10 @@ impl LayerObject for Example {
 impl ToBytes for Example {
     fn to_bytes_checksummed(
         &self,
-        bytes: &mut Vec<u8>,
+        writer: &mut PacketWriter<'_, Vec<u8>>,
         prev: Option<(LayerId, usize)>,
     ) -> Result<(), SerializationError> {
+        writer.update_layer::<Example>();
         todo!()
     }
 }

--- a/pkts/src/lib.rs
+++ b/pkts/src/lib.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! A library for creating, decoding and modifying packet layers.
+//! `pkts` - A library for creating, decoding and modifying packet layers.
 //!
 
 #![forbid(unsafe_code)]
@@ -17,11 +17,7 @@
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 extern crate alloc;
 
-use core::cmp;
-use error::SerializationError;
-use layers::dev_traits::LayerName;
-use pkts_common::{Buffer, BufferMut};
-
+pub mod dev_prelude;
 pub mod error;
 pub mod layers;
 #[doc(hidden)]
@@ -29,201 +25,15 @@ pub mod prelude;
 pub mod sequence;
 pub mod session;
 pub mod utils;
+pub mod writer;
 
 mod private {
     pub trait Sealed {}
 }
 
-pub struct PacketWriter<'a, T: IndexedWritable> {
-    writable: &'a mut T,
-    error_layer: &'static str,
-}
-
-impl<'a, T: IndexedWritable> PacketWriter<'a, T> {
-    /// Constructs a new writer with errors reported as originating from layer `L`.
-    pub fn new<L: LayerName>(writable: &'a mut T) -> Self {
-        Self {
-            writable,
-            error_layer: L::name(),
-        }
-    }
-
-    /// Writes the data to the writer at its current index.
-    pub fn write(&mut self, data: &[u8]) -> Result<(), SerializationError> {
-        self.writable.write(data).map_err(|e| match e {
-            IndexedWriteError::OutOfRange => panic!(),
-            IndexedWriteError::InsufficientBytes => {
-                SerializationError::insufficient_buffer(self.error_layer)
-            }
-        })
-    }
-
-    /// Writes the data at the specified index position.
-    ///
-    /// This method will panic if `pos` is greater than the current written length of the buffer.
-    pub fn write_at(&mut self, data: &[u8], pos: usize) -> Result<(), SerializationError> {
-        self.writable.write_at(data, pos).map_err(|e| match e {
-            IndexedWriteError::OutOfRange => panic!(),
-            IndexedWriteError::InsufficientBytes => {
-                SerializationError::insufficient_buffer(self.error_layer)
-            }
-        })
-    }
-
-    /// Returns the current index of the writer.
-    pub fn pos(&self) -> usize {
-        self.writable.pos()
-    }
-
-    /// Shifts the writer's index back to the provided index position, truncating the stream.
-    ///
-    /// This method will panic if `pos` is greater than the current written length of the buffer.
-    pub fn rewind_pos(&mut self, pos: usize) -> Result<(), SerializationError> {
-        self.writable.rewind_pos(pos).map_err(|e| match e {
-            IndexedWriteError::OutOfRange => panic!(),
-            IndexedWriteError::InsufficientBytes => {
-                SerializationError::insufficient_buffer(self.error_layer)
-            }
-        })
-    }
-}
-
-pub trait IndexedWritable {
-    /// Writes the data to the writer at its current index.
-    fn write(&mut self, data: &[u8]) -> Result<(), IndexedWriteError>;
-
-    /// Writes the data at the specified index position.
-    ///
-    /// This method will panic if `pos` is greater than the current written length of the buffer.
-    fn write_at(&mut self, data: &[u8], pos: usize) -> Result<(), IndexedWriteError>;
-
-    /// Returns the current index of the writer.
-    fn pos(&self) -> usize;
-
-    /// Shifts the writer's index back to the provided index position, truncating the stream.
-    ///
-    /// This method will panic if `pos` is greater than the current written length of the buffer.
-    fn rewind_pos(&mut self, pos: usize) -> Result<(), IndexedWriteError>;
-}
-
-impl IndexedWritable for Vec<u8> {
-    fn write(&mut self, data: &[u8]) -> Result<(), IndexedWriteError> {
-        self.extend(data);
-        Ok(())
-    }
-
-    fn write_at(&mut self, data: &[u8], pos: usize) -> Result<(), IndexedWriteError> {
-        if pos > self.len() {
-            return Err(IndexedWriteError::OutOfRange);
-        }
-
-        let split = cmp::max(self.len() - pos, data.len());
-
-        self[pos..pos + split].copy_from_slice(&data[..split]);
-        self.extend(&data[split..]);
-        Ok(())
-    }
-
-    fn pos(&self) -> usize {
-        self.len()
-    }
-
-    fn rewind_pos(&mut self, pos: usize) -> Result<(), IndexedWriteError> {
-        if pos > self.len() {
-            Err(IndexedWriteError::OutOfRange)
-        } else {
-            self.truncate(pos);
-            Ok(())
-        }
-    }
-}
-
-impl<const N: usize> IndexedWritable for Buffer<u8, N> {
-    fn write(&mut self, slice: &[u8]) -> Result<(), IndexedWriteError> {
-        self.append(slice);
-        Ok(())
-    }
-
-    fn write_at(&mut self, slice: &[u8], pos: usize) -> Result<(), IndexedWriteError> {
-        if pos > self.len() {
-            return Err(IndexedWriteError::OutOfRange);
-        }
-
-        let split = cmp::max(self.len() - pos, slice.len());
-
-        self.as_mut_slice()[pos..pos + split].copy_from_slice(&slice[..split]);
-        self.append(&slice[split..]);
-        Ok(())
-    }
-
-    fn pos(&self) -> usize {
-        self.len()
-    }
-
-    fn rewind_pos(&mut self, pos: usize) -> Result<(), IndexedWriteError> {
-        if pos > self.len() {
-            Err(IndexedWriteError::OutOfRange)
-        } else {
-            self.truncate(pos);
-            Ok(())
-        }
-    }
-}
-
-impl IndexedWritable for BufferMut<'_> {
-    fn write(&mut self, slice: &[u8]) -> Result<(), IndexedWriteError> {
-        self.append(slice);
-        Ok(())
-    }
-
-    fn write_at(&mut self, slice: &[u8], pos: usize) -> Result<(), IndexedWriteError> {
-        if pos > self.len() {
-            return Err(IndexedWriteError::OutOfRange);
-        }
-
-        let split = cmp::max(self.len() - pos, slice.len());
-
-        self.as_mut_slice()[pos..pos + split].copy_from_slice(&slice[..split]);
-        self.append(&slice[split..]);
-        Ok(())
-    }
-
-    fn pos(&self) -> usize {
-        self.len()
-    }
-
-    fn rewind_pos(&mut self, pos: usize) -> Result<(), IndexedWriteError> {
-        if pos > self.len() {
-            Err(IndexedWriteError::OutOfRange)
-        } else {
-            self.truncate(pos);
-            Ok(())
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub enum IndexedWriteError {
-    /// An attempted indexed write would write beyond the end of the writer's buffer.
-    OutOfRange,
-    /// An attempted write failed due to the underlying writable running out of storage space.
-    InsufficientBytes,
-}
-
-pub trait Readable {
-    fn read_slice(&mut self) -> Result<&[u8], SerializationError>;
-
-    fn read_byte(&mut self) -> Result<u8, SerializationError>;
-}
-
 #[cfg(test)]
 mod tests {
-    use crate::layers::ip::Ipv4;
-
-    use crate::layers::tcp::{Tcp, TcpRef};
-    use crate::layers::traits::*;
     use crate::layers::udp::*;
-    use crate::parse_layers;
     use crate::sequence::ipv4::*;
     use crate::sequence::LayeredSequence;
     use pkts_common::BufferMut;
@@ -266,22 +76,6 @@ mod tests {
 
         let _udp_packet = udp_builder.build().unwrap();
     }
-
-    /*
-    #[test]
-    fn from_the_layers() {
-        let bytes = b"hello".as_slice();
-        let _tcp = Tcp::from_bytes(bytes);
-
-        let tcpref = TcpRef::from_bytes_unchecked(bytes);
-
-        let _into_tcp: Tcp = tcpref.into();
-
-        let _layers = parse_layers!(bytes, Tcp, Tcp, Ipv4).unwrap();
-
-        //let layers = Tcp::from_layers(bytes, [Tcp, Ipv4, Tcp]);
-    }
-    */
 
     #[test]
     fn multi_layer_sequence() {

--- a/pkts/src/prelude.rs
+++ b/pkts/src/prelude.rs
@@ -10,7 +10,7 @@
 
 pub use pkts_common::{Buffer, BufferMut};
 
-pub use crate::error::{ValidationError, ValidationErrorClass};
+pub use crate::error::{SerializationError, ValidationError, ValidationErrorClass};
 pub use crate::layers::traits::*;
 pub use crate::layers::{Raw, RawRef};
 pub use crate::{parse_layers, parse_layers_unchecked};

--- a/pkts/src/writer.rs
+++ b/pkts/src/writer.rs
@@ -1,0 +1,290 @@
+use core::ops::{Index, Range, RangeFrom, RangeInclusive, RangeTo};
+use std::cmp;
+
+use crate::layers::dev_traits::LayerName;
+use crate::prelude::*;
+
+pub struct PacketWriter<'a, T: PacketWritable> {
+    writable: &'a mut T,
+    error_layer: &'static str, // TODO: remove?
+}
+
+impl<'a, T: PacketWritable> PacketWriter<'a, T> {
+    /// Constructs a new writer with errors reported as originating from layer `L`.
+    #[inline]
+    pub fn new<L: LayerName>(writable: &'a mut T) -> Self {
+        Self {
+            writable,
+            error_layer: L::name(),
+        }
+    }
+
+    /// Constructs a new writer with errors reported as originating from `layer_naem`.
+    #[inline]
+    pub(crate) fn new_with_layer(writable: &'a mut T, layer_name: &'static str) -> Self {
+        Self {
+            writable,
+            error_layer: layer_name,
+        }
+    }
+
+    /// Updates the `Layer` that errors will be reported as originating from.
+    #[inline]
+    pub fn update_layer<L: LayerName>(&mut self) {
+        self.error_layer = L::name();
+    }
+
+    /// Writes the data to the writer at its current index.
+    #[inline]
+    pub fn write_slice(&mut self, data: &[u8]) -> Result<(), SerializationError> {
+        self.writable.write_slice(data).map_err(|e| match e {
+            IndexedWriteError::OutOfRange => SerializationError::internal(self.error_layer),
+            IndexedWriteError::InsufficientBytes => {
+                SerializationError::insufficient_buffer(self.error_layer)
+            }
+        })
+    }
+
+    /// Writes data to the specified index position.
+    ///
+    /// This method will panic if `pos` is greater than the current written length of the buffer.
+    #[inline]
+    pub fn write_slice_at(&mut self, data: &[u8], pos: usize) -> Result<(), SerializationError> {
+        self.writable
+            .write_slice_at(data, pos)
+            .map_err(|e| match e {
+                IndexedWriteError::OutOfRange => SerializationError::internal(self.error_layer),
+                IndexedWriteError::InsufficientBytes => {
+                    SerializationError::insufficient_buffer(self.error_layer)
+                }
+            })
+    }
+
+    /// Returns the current length of bytes written to the writer.
+    ///
+    /// Note that this is NOT the amount of available space the writer has left to write to.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.writable.len()
+    }
+
+    /// Shifts the writer's index back to the provided index position, truncating the stream.
+    ///
+    /// This method will return an error if `pos` is greater than the current written length of the
+    /// buffer.
+    #[inline]
+    pub fn truncate(&mut self, num_bytes: usize) -> Result<(), SerializationError> {
+        self.writable.truncate(num_bytes).map_err(|e| match e {
+            IndexedWriteError::OutOfRange => SerializationError::internal(self.error_layer),
+            IndexedWriteError::InsufficientBytes => {
+                SerializationError::insufficient_buffer(self.error_layer)
+            }
+        })
+    }
+}
+
+impl<T: PacketWritable> Index<usize> for PacketWriter<'_, T> {
+    type Output = <T as Index<usize>>::Output;
+
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        self.writable.index(index)
+    }
+}
+
+impl<T: PacketWritable> Index<Range<usize>> for PacketWriter<'_, T> {
+    type Output = <T as Index<Range<usize>>>::Output;
+
+    #[inline]
+    fn index(&self, index: Range<usize>) -> &Self::Output {
+        self.writable.index(index)
+    }
+}
+
+impl<T: PacketWritable> Index<RangeFrom<usize>> for PacketWriter<'_, T> {
+    type Output = <T as Index<RangeFrom<usize>>>::Output;
+
+    #[inline]
+    fn index(&self, index: RangeFrom<usize>) -> &Self::Output {
+        self.writable.index(index)
+    }
+}
+
+impl<T: PacketWritable> Index<RangeInclusive<usize>> for PacketWriter<'_, T> {
+    type Output = <T as Index<RangeInclusive<usize>>>::Output;
+
+    #[inline]
+    fn index(&self, index: RangeInclusive<usize>) -> &Self::Output {
+        self.writable.index(index)
+    }
+}
+
+impl<T: PacketWritable> Index<RangeTo<usize>> for PacketWriter<'_, T> {
+    type Output = <T as Index<RangeTo<usize>>>::Output;
+
+    #[inline]
+    fn index(&self, index: RangeTo<usize>) -> &Self::Output {
+        self.writable.index(index)
+    }
+}
+
+pub trait PacketWritable:
+    Index<usize>
+    + Index<Range<usize>>
+    + Index<RangeFrom<usize>>
+    + Index<RangeInclusive<usize>>
+    + Index<RangeTo<usize>>
+{
+    /// Writes the data to the writer at its current index.
+    fn write_slice(&mut self, data: &[u8]) -> Result<(), IndexedWriteError>;
+
+    /// Writes the data at the specified index position.
+    ///
+    /// This method will panic if `pos` is greater than the current written length of the buffer.
+    fn write_slice_at(&mut self, data: &[u8], pos: usize) -> Result<(), IndexedWriteError>;
+
+    /// Returns the current length of bytes written to the writer.
+    ///
+    /// Note that this is NOT the amount of available space the writer has left to write to.
+    /// is
+    fn len(&self) -> usize;
+
+    /// Shifts the writer's index back to the provided index position, truncating the stream.
+    ///
+    /// This method will panic if `pos` is greater than the current written length of the buffer.
+    fn truncate(&mut self, pos: usize) -> Result<(), IndexedWriteError>;
+}
+
+impl PacketWritable for Vec<u8> {
+    #[inline]
+    fn write_slice(&mut self, data: &[u8]) -> Result<(), IndexedWriteError> {
+        self.extend(data);
+        Ok(())
+    }
+
+    #[inline]
+    fn write_slice_at(&mut self, data: &[u8], pos: usize) -> Result<(), IndexedWriteError> {
+        if pos > self.len() {
+            return Err(IndexedWriteError::OutOfRange);
+        }
+
+        let split = cmp::max(self.len() - pos, data.len());
+
+        self[pos..pos + split].copy_from_slice(&data[..split]);
+        self.extend(&data[split..]);
+        Ok(())
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    #[inline]
+    fn truncate(&mut self, pos: usize) -> Result<(), IndexedWriteError> {
+        if pos > self.len() {
+            Err(IndexedWriteError::OutOfRange)
+        } else {
+            self.truncate(pos);
+            Ok(())
+        }
+    }
+}
+
+impl<const N: usize> PacketWritable for Buffer<u8, N> {
+    #[inline]
+    fn write_slice(&mut self, slice: &[u8]) -> Result<(), IndexedWriteError> {
+        if self.remaining() < slice.len() {
+            return Err(IndexedWriteError::InsufficientBytes);
+        }
+
+        self.append(slice);
+        Ok(())
+    }
+
+    #[inline]
+    fn write_slice_at(&mut self, slice: &[u8], pos: usize) -> Result<(), IndexedWriteError> {
+        if pos > self.len() {
+            return Err(IndexedWriteError::OutOfRange);
+        }
+
+        let split = cmp::max(self.len() - pos, slice.len());
+
+        if self.remaining() < slice.len() - split {
+            return Err(IndexedWriteError::InsufficientBytes);
+        }
+
+        self.as_mut_slice()[pos..pos + split].copy_from_slice(&slice[..split]);
+        self.append(&slice[split..]);
+        Ok(())
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    #[inline]
+    fn truncate(&mut self, pos: usize) -> Result<(), IndexedWriteError> {
+        if pos > self.len() {
+            Err(IndexedWriteError::OutOfRange)
+        } else {
+            self.truncate(pos);
+            Ok(())
+        }
+    }
+}
+
+impl PacketWritable for BufferMut<'_> {
+    #[inline]
+    fn write_slice(&mut self, slice: &[u8]) -> Result<(), IndexedWriteError> {
+        if self.remaining() < slice.len() {
+            return Err(IndexedWriteError::InsufficientBytes);
+        }
+
+        self.append(slice);
+        Ok(())
+    }
+
+    #[inline]
+    fn write_slice_at(&mut self, slice: &[u8], pos: usize) -> Result<(), IndexedWriteError> {
+        if pos > self.len() {
+            return Err(IndexedWriteError::OutOfRange);
+        }
+
+        let split = cmp::max(self.len() - pos, slice.len());
+
+        if self.remaining() < slice.len() - split {
+            return Err(IndexedWriteError::InsufficientBytes);
+        }
+
+        self.as_mut_slice()[pos..pos + split].copy_from_slice(&slice[..split]);
+        self.append(&slice[split..]);
+        Ok(())
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    #[inline]
+    fn truncate(&mut self, pos: usize) -> Result<(), IndexedWriteError> {
+        if pos > self.len() {
+            Err(IndexedWriteError::OutOfRange)
+        } else {
+            self.truncate(pos);
+            Ok(())
+        }
+    }
+}
+
+/// An error in performing an indexed write.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub enum IndexedWriteError {
+    /// An attempted indexed write would write beyond the end of the writer's buffer.
+    OutOfRange,
+    /// An attempted write failed due to the underlying writable running out of storage space.
+    InsufficientBytes,
+}


### PR DESCRIPTION
The `PacketWriter` struct and `PacketWritable` trait help to make serialization code reusable for both `*Builder` and `Layer` types. This PR integrates it into existing serialization methods.