### PR TITLE
Lower MSRV to 1.65

### DIFF
--- a/.github/workflows/full_ci.yaml
+++ b/.github/workflows/full_ci.yaml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.77.0
+          - 1.65.0
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust toolchain

--- a/pkts-common/Cargo.toml
+++ b/pkts-common/Cargo.toml
@@ -2,6 +2,7 @@
 name = "pkts-common"
 authors = ["Nathaniel Bennett <me[at]nathanielbennett[dotcom]>"]
 description = "helper library for shared types/utilities among rscap and pkts"
+rust-version = "1.65"
 license = "MIT OR Apache-2.0"
 version = "0.2.0"
 edition = "2021"

--- a/pkts-macros/Cargo.toml
+++ b/pkts-macros/Cargo.toml
@@ -3,6 +3,7 @@ name = "pkts-macros"
 description = "procedural macros for deriving `pkts` library traits"
 authors = ["Nathaniel Bennett <me[at]nathanielbennett[dotcom]>"]
 license = "MIT OR Apache-2.0"
+rust-version = "1.65"
 version = "0.2.0"
 edition = "2021"
 repository = "https://github.com/pkts-rs/pkts"

--- a/pkts/Cargo.toml
+++ b/pkts/Cargo.toml
@@ -2,12 +2,15 @@
 name = "pkts"
 authors = ["Nathaniel Bennett <me[at]nathanielbennett[dotcom]>"]
 description = "tools for building, inspecting and modifying network protocol packets"
-# 1.65 - GATs stabilized (required for some `Sequence` types)
-# 1.77 - `core::net` stabilized (needed for `no-std` IpAddr types)
-rust-version = "1.77"
+# 1.56 - Rust edition 2021 released; `bitflags`/`quote`/`proc_macro2` MSRV
+# 1.61 - `syn` MSRV
+# 1.63 - `array::from_fn` stabilized
+# 1.65 - GATs stabilized (required for some `Sequence` types); `core::CStr` stabilized (our MSRV)
+# 1.77 - `core::net` stabilized (needed for `no-std` `IpAddr` types)--handled by cfg
+rust-version = "1.65"
 license = "MIT OR Apache-2.0"
 version = "0.2.0"
-edition = "2021"
+edition = "2018"
 repository = "https://github.com/pkts-rs/pkts"
 keywords = ["packets", "network", "scapy", "parsing"]
 categories = ["network-programming", "encoding", "parsing"]

--- a/pkts/build.rs
+++ b/pkts/build.rs
@@ -1,0 +1,68 @@
+use std::process::{Command, Output};
+use std::{env, str};
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let version = rustc_minor_version();
+
+    if version >= 77 {
+        set_cfg("rustc_1_77");
+    }
+}
+
+fn rustc_version_cmd(is_clippy_driver: bool) -> Output {
+    let rustc = env::var_os("RUSTC").expect("Failed to get rustc version: missing RUSTC env");
+
+    let mut cmd = match env::var_os("RUSTC_WRAPPER") {
+        Some(ref wrapper) if wrapper.is_empty() => Command::new(rustc),
+        Some(wrapper) => {
+            let mut cmd = Command::new(wrapper);
+            cmd.arg(rustc);
+            if is_clippy_driver {
+                cmd.arg("--rustc");
+            }
+
+            cmd
+        }
+        None => Command::new(rustc),
+    };
+
+    cmd.arg("--version");
+
+    let output = cmd.output().expect("Failed to get rustc version");
+
+    if !output.status.success() {
+        panic!(
+            "failed to run rustc: {}",
+            String::from_utf8_lossy(output.stderr.as_slice())
+        );
+    }
+
+    output
+}
+
+fn rustc_minor_version() -> u32 {
+    let mut output = rustc_version_cmd(false);
+
+    if str::from_utf8(&output.stdout)
+        .unwrap()
+        .starts_with("clippy")
+    {
+        output = rustc_version_cmd(true);
+    }
+
+    let version = str::from_utf8(&output.stdout).unwrap();
+
+    let mut pieces = version.split('.');
+
+    if pieces.next() != Some("rustc 1") {
+        panic!("Rust version missing beginning `rustc 1.` tag");
+    }
+
+    pieces.next().unwrap().parse().unwrap()
+}
+
+fn set_cfg(cfg: &str) {
+    println!("cargo:rustc-cfg={}", cfg);
+}

--- a/pkts/src/layers/dev_traits.rs
+++ b/pkts/src/layers/dev_traits.rs
@@ -13,6 +13,7 @@
 //!
 
 use core::any;
+use core::convert::{TryFrom, TryInto};
 
 use crate::prelude::*;
 

--- a/pkts/src/layers/diameter.rs
+++ b/pkts/src/layers/diameter.rs
@@ -12,14 +12,15 @@
 //!
 //!
 
+use core::convert::{TryFrom, TryInto};
+use core::iter::Iterator;
+use core::{cmp, slice};
+
 use crate::layers::dev_traits::*;
 use crate::layers::traits::*;
 use crate::layers::*;
 use crate::utils;
 use crate::writer::PacketWritable;
-
-use core::iter::Iterator;
-use core::{cmp, slice};
 
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 use alloc::boxed::Box;

--- a/pkts/src/layers/l2.rs
+++ b/pkts/src/layers/l2.rs
@@ -12,6 +12,7 @@
 //!
 //!
 
+use core::convert::{TryFrom, TryInto};
 use core::slice;
 
 use pkts_macros::{Layer, LayerRef, StatelessLayer};

--- a/pkts/src/layers/mysql.rs
+++ b/pkts/src/layers/mysql.rs
@@ -12,6 +12,7 @@
 //!
 
 use core::cmp::Ordering;
+use core::convert::{TryFrom, TryInto};
 use core::slice;
 
 use super::Raw;

--- a/pkts/src/layers/psql.rs
+++ b/pkts/src/layers/psql.rs
@@ -11,12 +11,12 @@
 //! Protocol layers used for communication between PostgreSQL clients and databases.
 //!
 
+use core::convert::{TryFrom, TryInto};
 use core::ffi::CStr;
-#[cfg(feature = "std")]
-use std::collections::BTreeMap;
-
 use core::iter::Iterator;
 use core::{cmp, str};
+#[cfg(feature = "std")]
+use std::collections::BTreeMap;
 #[cfg(feature = "std")]
 use std::ffi::CString;
 

--- a/pkts/src/layers/sctp.rs
+++ b/pkts/src/layers/sctp.rs
@@ -12,8 +12,12 @@
 //!
 //!
 
+use core::convert::{TryFrom, TryInto};
 use core::iter::Iterator;
 use core::{cmp, mem, slice};
+
+#[cfg(feature = "std")]
+use std::iter::FromIterator;
 
 use crate::layers::dev_traits::*;
 use crate::layers::traits::*;

--- a/pkts/src/layers/tcp.rs
+++ b/pkts/src/layers/tcp.rs
@@ -15,6 +15,7 @@
 
 pub mod mptcp;
 
+use core::convert::{TryFrom, TryInto};
 use core::{cmp, mem, slice};
 
 use crate::layers::dev_traits::*;

--- a/pkts/src/layers/tcp/mptcp.rs
+++ b/pkts/src/layers/tcp/mptcp.rs
@@ -1,7 +1,9 @@
-use core::{
-    array, mem,
-    net::{IpAddr, Ipv4Addr, Ipv6Addr},
-};
+use core::convert::{TryFrom, TryInto};
+#[cfg(all(not(feature = "std"), rustc_1_77))]
+use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use core::{array, mem};
+#[cfg(feature = "std")]
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use bitflags::bitflags;
 

--- a/pkts/src/layers/traits.rs
+++ b/pkts/src/layers/traits.rs
@@ -12,6 +12,7 @@
 //!
 //!
 
+use core::convert::{TryFrom, TryInto};
 use core::fmt::Debug;
 
 use super::dev_traits::*;

--- a/pkts/src/layers/udp.rs
+++ b/pkts/src/layers/udp.rs
@@ -20,6 +20,7 @@
 //! may use heap allocations) or [`UdpBuilder`], which constructs a UDP packet entirely within
 //! a stack-allocated byte array.
 
+use core::convert::{TryFrom, TryInto};
 use core::fmt::Debug;
 use core::{cmp, slice};
 

--- a/pkts/src/sequence/sctp.rs
+++ b/pkts/src/sequence/sctp.rs
@@ -1,7 +1,11 @@
-use core::{cmp::Ordering, mem};
+use core::cmp::Ordering;
+use core::convert::TryInto;
+use core::mem;
 
 #[cfg(feature = "std")]
 use std::collections::{BTreeMap, VecDeque};
+#[cfg(feature = "std")]
+use std::iter::FromIterator;
 
 use super::{PktFilterDynFn, Sequence, SequenceObject, UnboundedSequence};
 use crate::layers::sctp::{DataChunkFlags, SctpRef};

--- a/pkts/src/utils.rs
+++ b/pkts/src/utils.rs
@@ -17,6 +17,8 @@
 
 use core::{array, default, mem};
 
+use core::convert::TryInto;
+
 //#[cfg(all(not(feature = "std"), feature = "alloc"))]
 //use alloc::vec::Vec;
 

--- a/pktspec/Cargo.toml
+++ b/pktspec/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "pktspec"
 authors = ["Nathaniel Bennett <me[at]nathanielbennett[dotcom]>"]
+rust-version = "1.65"
 version = "0.1.0"
 edition = "2021"
 


### PR DESCRIPTION
Lowers the MSRV of all `pkts` crates to 1.65. This will be the planned stable MSRV for a good long while.

Resolves #2