### PR TITLE
Run CI on more feature combinations

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -25,19 +25,22 @@ do
     sleep 1
 done
 
-case "${OS}" in
-    windows*)
-        cargo test --features wintun
+echo "Testing default features"
 
-        cargo test --features wintun-runtime
+cargo test
 
-        cargo test --features tapwin6
+echo "Testing no default features (no std, no alloc)"
 
-        cargo test --features tapwin6-runtime
-        ;;
-    *)
-        # No extra features in any platform other than windows
+cargo test --no-default-features
 
-        cargo test
-        ;;
-esac
+echo "Testing only alloc"
+
+cargo test --features alloc
+
+echo "Testing std without error strings or custom layer selection"
+
+cargo test --features std
+
+echo "Testing no-std,no-alloc with error strings and custom layer selection"
+
+cargo test --features custom_layer_selection,error_string

--- a/pkts/Cargo.toml
+++ b/pkts/Cargo.toml
@@ -15,6 +15,9 @@ repository = "https://github.com/pkts-rs/pkts"
 keywords = ["packets", "network", "scapy", "parsing"]
 categories = ["network-programming", "encoding", "parsing"]
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(rustc_1_77)'] }
+
 [features]
 default = ["std", "custom_layer_selection", "error_string"]
 std = ["alloc"]

--- a/pkts/src/layers.rs
+++ b/pkts/src/layers.rs
@@ -48,7 +48,9 @@ use crate::layers::dev_traits::*;
 use crate::layers::traits::*;
 use crate::writer::PacketWriter;
 
-use pkts_macros::{Layer, LayerRef, StatelessLayer};
+#[cfg(feature = "alloc")]
+use pkts_macros::Layer;
+use pkts_macros::{LayerRef, StatelessLayer};
 
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 use alloc::boxed::Box;
@@ -79,6 +81,7 @@ pub enum Cardinal<T> {
 /// [`Ipv4`]: struct@crate::layers::ip::Ipv4
 /// [`Tcp`]: struct@crate::layers::tcp::Tcp
 /// [`Udp`]: struct@crate::layers::udp::Udp
+#[cfg(feature = "alloc")]
 #[derive(Clone, Debug, Layer, StatelessLayer)]
 #[metadata_type(RawMetadata)]
 #[ref_type(RawRef)]
@@ -88,6 +91,7 @@ pub struct Raw {
     // payload: Option<Box<dyn LayerObject>>,
 }
 
+#[cfg(feature = "alloc")]
 impl LayerLength for Raw {
     #[inline]
     fn len(&self) -> usize {
@@ -99,6 +103,7 @@ impl LayerLength for Raw {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl LayerObject for Raw {
     #[inline]
     fn can_add_payload_default(&self, _payload: &dyn LayerObject) -> bool {
@@ -126,6 +131,7 @@ impl LayerObject for Raw {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl ToBytes for Raw {
     fn to_bytes_checksummed(
         &self,
@@ -138,6 +144,7 @@ impl ToBytes for Raw {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl FromBytesCurrent for Raw {
     #[inline]
     fn payload_from_bytes_unchecked_default(&mut self, _bytes: &[u8]) {
@@ -152,6 +159,7 @@ impl FromBytesCurrent for Raw {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl Raw {
     /// A slice of the entire contents of the `Raw` layer.
     #[inline]

--- a/pkts/src/layers/diameter.rs
+++ b/pkts/src/layers/diameter.rs
@@ -12,14 +12,18 @@
 //!
 //!
 
-use core::convert::{TryFrom, TryInto};
+use core::cmp;
+#[cfg(feature = "alloc")]
+use core::convert::TryInto;
 use core::iter::Iterator;
-use core::{cmp, slice};
+#[cfg(feature = "alloc")]
+use core::slice;
 
 use crate::layers::dev_traits::*;
 use crate::layers::traits::*;
 use crate::layers::*;
 use crate::utils;
+#[cfg(feature = "alloc")]
 use crate::writer::PacketWritable;
 
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
@@ -29,6 +33,7 @@ use alloc::vec::Vec;
 
 use bitflags::bitflags;
 
+#[cfg(feature = "alloc")]
 #[derive(Clone, Debug, Layer, StatelessLayer)]
 #[metadata_type(DiameterMetadata)]
 #[ref_type(DiameterRef)]
@@ -43,6 +48,7 @@ pub struct Diameter {
     payload: Option<Box<dyn LayerObject>>, // Kept for compatibility purposes // TODO: remove?
 }
 
+#[cfg(feature = "alloc")]
 impl Diameter {
     #[inline]
     pub fn version(&self) -> u8 {
@@ -119,6 +125,7 @@ impl Diameter {
     }
 }
 
+#[cfg(feature = "alloc")]
 #[doc(hidden)]
 impl FromBytesCurrent for Diameter {
     #[inline]
@@ -146,6 +153,7 @@ impl FromBytesCurrent for Diameter {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl LayerLength for Diameter {
     #[inline]
     fn len(&self) -> usize {
@@ -156,6 +164,7 @@ impl LayerLength for Diameter {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl LayerObject for Diameter {
     #[inline]
     fn can_add_payload_default(&self, _payload: &dyn LayerObject) -> bool {
@@ -193,6 +202,7 @@ impl LayerObject for Diameter {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl ToBytes for Diameter {
     fn to_bytes_checksummed(
         &self,
@@ -310,7 +320,7 @@ impl Validate for DiameterRef<'_> {
                 // Validate length field (too big) and header bytes
                 if cmp::max(20, len) > curr_layer.len() {
                     return Err(ValidationError {
-                        layer: Diameter::name(),
+                        layer: Self::name(),
                         class: ValidationErrorClass::InsufficientBytes,
                         #[cfg(feature = "error_string")]
                         reason: "insufficient bytes in Diameter packet for header/Data payload",
@@ -320,7 +330,7 @@ impl Validate for DiameterRef<'_> {
                 // Validate length field (too small)
                 if len < 20 {
                     return Err(ValidationError {
-                        layer: Diameter::name(),
+                        layer: Self::name(),
                         class: ValidationErrorClass::InsufficientBytes,
                         #[cfg(feature = "error_string")]
                         reason: "Diameter packet Length field was too small for header",
@@ -329,7 +339,7 @@ impl Validate for DiameterRef<'_> {
 
                 if len % 4 != 0 {
                     return Err(ValidationError {
-                        layer: Diameter::name(),
+                        layer: Self::name(),
                         class: ValidationErrorClass::InvalidValue,
                         #[cfg(feature = "error_string")]
                         reason: "Diameter packet Length field was not a multiple of 4",
@@ -354,7 +364,7 @@ impl Validate for DiameterRef<'_> {
                 // Check for trailing bytes
                 if len < curr_layer.len() {
                     Err(ValidationError {
-                        layer: Diameter::name(),
+                        layer: Self::name(),
                         class: ValidationErrorClass::ExcessBytes(curr_layer.len() - len),
                         #[cfg(feature = "error_string")]
                         reason: "extra bytes remain at end of Diameter packet",
@@ -364,7 +374,7 @@ impl Validate for DiameterRef<'_> {
                 }
             }
             _ => Err(ValidationError {
-                layer: Diameter::name(),
+                layer: Self::name(),
                 class: ValidationErrorClass::InsufficientBytes,
                 #[cfg(feature = "error_string")]
                 reason: "insufficient bytes in DiameterRef for Message Length field",
@@ -414,6 +424,7 @@ pub const DIAM_BASE_COMM_SESSION_TERM: u32 = 275;
 #[derive(Clone, Debug, Layer, StatelessLayer)]
 #[metadata_type(DiamBaseMetadata)]
 #[ref_type(DiamBaseRef)]
+#[cfg(feature = "alloc")]
 pub struct DiamBase {
     // version: u8, // version must be equal to 1
     flags: CommandFlags,
@@ -424,6 +435,7 @@ pub struct DiamBase {
     payload: Option<Box<dyn LayerObject>>, // Kept for compatibility purposes // TODO: remove?
 }
 
+#[cfg(feature = "alloc")]
 impl DiamBase {
     #[inline]
     pub fn version(&self) -> u8 {
@@ -486,6 +498,7 @@ impl DiamBase {
     }
 }
 
+#[cfg(feature = "alloc")]
 #[doc(hidden)]
 impl FromBytesCurrent for DiamBase {
     #[inline]
@@ -518,6 +531,7 @@ impl FromBytesCurrent for DiamBase {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl LayerLength for DiamBase {
     #[inline]
     fn len(&self) -> usize {
@@ -528,6 +542,7 @@ impl LayerLength for DiamBase {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl LayerObject for DiamBase {
     #[inline]
     fn can_add_payload_default(&self, _payload: &dyn LayerObject) -> bool {
@@ -566,6 +581,7 @@ impl LayerObject for DiamBase {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl ToBytes for DiamBase {
     fn to_bytes_checksummed(
         &self,
@@ -680,7 +696,7 @@ impl Validate for DiamBaseRef<'_> {
                 // Validate length field (too big) and header bytes
                 if cmp::max(20, len) > curr_layer.len() {
                     return Err(ValidationError {
-                        layer: Diameter::name(),
+                        layer: Self::name(),
                         class: ValidationErrorClass::InsufficientBytes,
                         #[cfg(feature = "error_string")]
                         reason: "insufficient bytes in Diameter packet for header/Data payload",
@@ -690,7 +706,7 @@ impl Validate for DiamBaseRef<'_> {
                 // Validate length field (too small)
                 if len < 20 {
                     return Err(ValidationError {
-                        layer: Diameter::name(),
+                        layer: Self::name(),
                         class: ValidationErrorClass::InsufficientBytes,
                         #[cfg(feature = "error_string")]
                         reason: "Diameter packet Length field was too small for header",
@@ -699,7 +715,7 @@ impl Validate for DiamBaseRef<'_> {
 
                 if len % 4 != 0 {
                     return Err(ValidationError {
-                        layer: Diameter::name(),
+                        layer: Self::name(),
                         class: ValidationErrorClass::InvalidValue,
                         #[cfg(feature = "error_string")]
                         reason: "Diameter packet Length field was not a multiple of 4",
@@ -724,7 +740,7 @@ impl Validate for DiamBaseRef<'_> {
                 // Check for trailing bytes
                 if len < curr_layer.len() {
                     Err(ValidationError {
-                        layer: Diameter::name(),
+                        layer: Self::name(),
                         class: ValidationErrorClass::ExcessBytes(curr_layer.len() - len),
                         #[cfg(feature = "error_string")]
                         reason: "extra bytes remain at end of Diameter packet",
@@ -734,7 +750,7 @@ impl Validate for DiamBaseRef<'_> {
                 }
             }
             _ => Err(ValidationError {
-                layer: Diameter::name(),
+                layer: Self::name(),
                 class: ValidationErrorClass::InsufficientBytes,
                 #[cfg(feature = "error_string")]
                 reason: "insufficient bytes in DiameterRef for Message Length field",
@@ -900,6 +916,7 @@ bitflags! {
     }
 }
 
+#[cfg(feature = "alloc")]
 #[derive(Clone, Debug)]
 pub enum BaseCommand {
     AbortSessionReq(AbortSessionReq),
@@ -919,6 +936,7 @@ pub enum BaseCommand {
     /* TODO: Uncomprehensive list annotation */
 }
 
+#[cfg(feature = "alloc")]
 impl BaseCommand {
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, ValidationError> {
         Self::validate(bytes)?;
@@ -957,10 +975,12 @@ impl BaseCommand {
 
     #[inline]
     pub fn to_bytes_extended<T: PacketWritable>(&self, writer: &mut PacketWriter<'_, T>) {
+        writer.update_layer::<DiamBase>();
         todo!()
     }
 }
 
+/*
 pub enum BaseCommandRef<'a> {
     AbortSessionReq(AbortSessionReqRef<'a>),
     AbortSessionAns(AbortSessionAns),
@@ -978,12 +998,15 @@ pub enum BaseCommandRef<'a> {
     SessionTermAns(SessionTermAns),
     /* TODO: Uncomprehensive list annotation */
 }
+*/
 
 #[derive(Clone, Debug)]
+#[cfg(feature = "alloc")]
 pub struct AbortSessionReq {
     avps: Vec<BaseAvp>,
 }
 
+#[cfg(feature = "alloc")]
 impl AbortSessionReq {
     #[inline]
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, ValidationError> {
@@ -1013,81 +1036,96 @@ impl AbortSessionReq {
 }
 
 pub struct AbortSessionReqRef<'a> {
-    data: &'a [u8],
+    _data: &'a [u8],
 }
 
 impl<'a> AbortSessionReqRef<'a> {}
 
+#[cfg(feature = "alloc")]
 #[derive(Clone, Debug)]
 pub struct AbortSessionAns {
-    avps: Vec<BaseAvp>,
+    _avps: Vec<BaseAvp>,
 }
 
+#[cfg(feature = "alloc")]
 #[derive(Clone, Debug)]
 pub struct AccountingReq {
-    avps: Vec<BaseAvp>,
+    _avps: Vec<BaseAvp>,
 }
 
+#[cfg(feature = "alloc")]
 #[derive(Clone, Debug)]
 pub struct AccountingAns {
-    avps: Vec<BaseAvp>,
+    _avps: Vec<BaseAvp>,
 }
 
+#[cfg(feature = "alloc")]
 #[derive(Clone, Debug)]
 pub struct CapExchangeReq {
-    avps: Vec<BaseAvp>,
+    _avps: Vec<BaseAvp>,
 }
 
+#[cfg(feature = "alloc")]
 #[derive(Clone, Debug)]
 pub struct CapExchangeAns {
-    avps: Vec<BaseAvp>,
+    _avps: Vec<BaseAvp>,
 }
 
+#[cfg(feature = "alloc")]
 #[derive(Clone, Debug)]
 pub struct DevWatchdogReq {
-    avps: Vec<BaseAvp>,
+    _avps: Vec<BaseAvp>,
 }
 
+#[cfg(feature = "alloc")]
 #[derive(Clone, Debug)]
 pub struct DevWatchdogAns {
-    avps: Vec<BaseAvp>,
+    _avps: Vec<BaseAvp>,
 }
 
+#[cfg(feature = "alloc")]
 #[derive(Clone, Debug)]
 pub struct DisconnectPeerReq {
-    avps: Vec<BaseAvp>,
+    _avps: Vec<BaseAvp>,
 }
 
+#[cfg(feature = "alloc")]
 #[derive(Clone, Debug)]
 pub struct DisconnectPeerAns {
-    avps: Vec<BaseAvp>,
+    _avps: Vec<BaseAvp>,
 }
 
+#[cfg(feature = "alloc")]
 #[derive(Clone, Debug)]
 pub struct ReAuthReq {
-    avps: Vec<BaseAvp>,
+    _avps: Vec<BaseAvp>,
 }
 
+#[cfg(feature = "alloc")]
 #[derive(Clone, Debug)]
 pub struct ReAuthAns {
-    avps: Vec<BaseAvp>,
+    _avps: Vec<BaseAvp>,
 }
 
+#[cfg(feature = "alloc")]
 #[derive(Clone, Debug)]
 pub struct SessionTermReq {
-    avps: Vec<BaseAvp>,
+    _avps: Vec<BaseAvp>,
 }
 
+#[cfg(feature = "alloc")]
 #[derive(Clone, Debug)]
 pub struct SessionTermAns {
-    avps: Vec<BaseAvp>,
+    _avps: Vec<BaseAvp>,
 }
 
+#[cfg(feature = "alloc")]
 #[derive(Clone, Debug)]
 pub enum BaseAvp {
     Other(GenericAvp),
 }
 
+#[cfg(feature = "alloc")]
 impl From<BaseAvpRef<'_>> for BaseAvp {
     #[inline]
     fn from(value: BaseAvpRef<'_>) -> Self {
@@ -1095,6 +1133,7 @@ impl From<BaseAvpRef<'_>> for BaseAvp {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl From<&BaseAvpRef<'_>> for BaseAvp {
     fn from(value: &BaseAvpRef<'_>) -> Self {
         match value {
@@ -1151,6 +1190,7 @@ impl<'a> Iterator for BaseAvpIterRef<'a> {
 
 // TODO: write a macro to generalize work for AVPs
 pub mod avp {
+    #[cfg(feature = "alloc")]
     use super::{BaseAvp, GenericAvp};
 
     #[cfg(all(not(feature = "std"), feature = "alloc"))]
@@ -1159,7 +1199,7 @@ pub mod avp {
     use alloc::vec::Vec;
 
     pub struct AcctInterimInterval {
-        interval: u32,
+        _interval: u32,
     }
 
     #[repr(i32)]
@@ -1170,12 +1210,13 @@ pub mod avp {
         Unknown(i32),
     }
 
+    #[cfg(feature = "alloc")]
     pub struct AcctMultiSessionId {
-        session_id: String,
+        _session_id: String,
     }
 
     pub struct AcctRecordNumber {
-        record_number: u32,
+        _record_number: u32,
     }
 
     pub enum AcctRecordType {
@@ -1186,20 +1227,21 @@ pub mod avp {
         Unknown(i32),
     }
 
+    #[cfg(feature = "alloc")]
     pub struct AcctSessionId {
-        session_id: Vec<u8>,
+        _session_id: Vec<u8>,
     }
 
     pub struct AcctSubSessionId {
-        sub_session_id: u64,
+        _sub_session_id: u64,
     }
 
     pub struct AcctApplicationId {
-        application_id: u32,
+        _application_id: u32,
     }
 
     pub struct AuthApplicationId {
-        application_id: u32,
+        _application_id: u32,
     }
 
     pub enum AuthRequestType {
@@ -1210,11 +1252,11 @@ pub mod avp {
     }
 
     pub struct AuthLifetime {
-        lifetime: u32,
+        _lifetime: u32,
     }
 
     pub struct AuthGracePeriod {
-        grace_period: u32,
+        _grace_period: u32,
     }
 
     pub enum AuthSessionState {
@@ -1229,16 +1271,19 @@ pub mod avp {
         Unknown(i32),
     }
 
+    #[cfg(feature = "alloc")]
     pub struct Class {
-        class: Vec<u8>,
+        _class: Vec<u8>,
     }
 
+    #[cfg(feature = "alloc")]
     pub struct DestinationHost {
-        host_id: String, // Diameter Identity
+        _host_id: String, // Diameter Identity
     }
 
+    #[cfg(feature = "alloc")]
     pub struct DestinationRealm {
-        realm_id: String, // Diameter Identity
+        _realm_id: String, // Diameter Identity
     }
 
     pub enum DisconnectCause {
@@ -1248,78 +1293,90 @@ pub mod avp {
         Unknown(i32),
     }
 
+    #[cfg(feature = "alloc")]
     pub struct ErrorMessage {
-        message: String,
+        _message: String,
     }
 
+    #[cfg(feature = "alloc")]
     pub struct ErrorReportingHost {
-        id: String, // Diameter Identity
+        _id: String, // Diameter Identity
     }
 
     pub struct EventTimestamp {
-        time: u32,
+        _time: u32,
     }
 
+    #[cfg(feature = "alloc")]
     pub struct ExperimentalResult {
-        avps: Vec<BaseAvp>, // 1x Vendor-Id, 1x Experimental-Result-Code (any order)
+        _avps: Vec<BaseAvp>, // 1x Vendor-Id, 1x Experimental-Result-Code (any order)
     }
 
     pub struct ExperimentalResultCode {
-        res_code: u32,
+        _res_code: u32,
     }
 
+    #[cfg(feature = "alloc")]
     pub struct FailedAvp {
-        failed_avps: Vec<GenericAvp>,
+        _failed_avps: Vec<GenericAvp>,
     }
 
     pub struct FirmwareRevision {
-        rev: u32,
+        _rev: u32,
     }
 
+    #[cfg(feature = "alloc")]
     pub struct HostIpAddress {
         // Address type:
-        addr_type: u16,
-        addr_value: Vec<u8>,
+        _addr_type: u16,
+        _addr_value: Vec<u8>,
     }
 
     pub struct InbandSecurityId {
-        security_id: u32,
+        _security_id: u32,
     }
 
     pub struct MultiRoundTimeout {
-        timeout: u32,
+        _timeout: u32,
     }
 
+    #[cfg(feature = "alloc")]
     pub struct OriginHost {
-        id: String, // Diameter Identity
+        _id: String, // Diameter Identity
     }
 
+    #[cfg(feature = "alloc")]
     pub struct OriginRealm {
-        id: String, // Diameter Identity
+        _id: String, // Diameter Identity
     }
 
     pub struct OriginStateId {
-        state_id: u32,
+        _state_id: u32,
     }
 
+    #[cfg(feature = "alloc")]
     pub struct ProductName {
-        name: String,
+        _name: String,
     }
 
+    #[cfg(feature = "alloc")]
     pub struct ProxyHost {
-        id: String, // Diameter Identity
+        _id: String, // Diameter Identity
     }
 
+    #[cfg(feature = "alloc")]
     pub struct ProxyInfo {
-        apvs: Vec<BaseAvp>, // { Proxy-Host } { Proxy-State } *[ AVP ]
+        _apvs: Vec<BaseAvp>, // { Proxy-Host } { Proxy-State } *[ AVP ]
     }
 
+    #[cfg(feature = "alloc")]
     pub struct ProxyState {
-        state: Vec<u8>,
+        _state: Vec<u8>,
     }
 
+    #[cfg(feature = "alloc")]
     pub struct RedirectHost {
-        uri: String, // Diameter URI
+        _uri: String, // Diameter URI
     }
 
     pub enum RedirectHostUsage {
@@ -1334,27 +1391,29 @@ pub mod avp {
     }
 
     pub struct RedirectMaxCacheTime {
-        cache_time: u32,
+        _cache_time: u32,
     }
 
     pub struct ResultCode {
-        code: u32,
+        _code: u32,
     }
 
+    #[cfg(feature = "alloc")]
     pub struct RouteRecord {
-        id: String, // Diameter Identity
+        _id: String, // Diameter Identity
     }
 
+    #[cfg(feature = "alloc")]
     pub struct SessionId {
-        id: String,
+        _id: String,
     }
 
     pub struct SessionTimeout {
-        timeout: u32,
+        _timeout: u32,
     }
 
     pub struct SessionBinding {
-        binding: u32,
+        _binding: u32,
     }
 
     pub enum SessionServerFailover {
@@ -1365,7 +1424,7 @@ pub mod avp {
     }
 
     pub struct SupportedVendorId {
-        id: u32,
+        _id: u32,
     }
 
     pub enum TerminationCause {
@@ -1403,16 +1462,18 @@ pub mod avp {
         Unassigned(i32),              // < 0, 9, 10, > 32
     }
 
+    #[cfg(feature = "alloc")]
     pub struct UserName {
-        username: String,
+        _username: String,
     }
 
     pub struct VendorId {
-        id: u32,
+        _id: u32,
     }
 
+    #[cfg(feature = "alloc")]
     pub struct VendorSpecificApplicationId {
-        avps: Vec<BaseAvp>, // 1 Vendor-Id required, 1 Auth-Application-Id and 1 Acct-Application-Id both optional
+        _avps: Vec<BaseAvp>, // 1 Vendor-Id required, 1 Auth-Application-Id and 1 Acct-Application-Id both optional
     }
 }
 
@@ -1467,6 +1528,7 @@ pub enum S6aCommand {
 /// +-+-+-+-+-+-+-+-+
 /// ```
 #[derive(Clone, Debug)]
+#[cfg(feature = "alloc")]
 pub struct GenericAvp {
     code: u32,
     flags: AvpFlags,
@@ -1474,6 +1536,7 @@ pub struct GenericAvp {
     data: Vec<u8>,
 }
 
+#[cfg(feature = "alloc")]
 impl GenericAvp {
     #[inline]
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, ValidationError> {
@@ -1581,6 +1644,7 @@ impl GenericAvp {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl From<GenericAvpRef<'_>> for GenericAvp {
     #[inline]
     fn from(value: GenericAvpRef<'_>) -> Self {
@@ -1588,6 +1652,7 @@ impl From<GenericAvpRef<'_>> for GenericAvp {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl From<&GenericAvpRef<'_>> for GenericAvp {
     fn from(value: &GenericAvpRef<'_>) -> Self {
         GenericAvp {
@@ -1631,7 +1696,7 @@ impl<'a> GenericAvpRef<'a> {
                 // Validate length field (too big) and header bytes
                 if cmp::max(minimum_length, len) > bytes.len() {
                     return Err(ValidationError {
-                        layer: Diameter::name(),
+                        layer: DiamBaseRef::name(),
                         class: ValidationErrorClass::InsufficientBytes,
                         #[cfg(feature = "error_string")]
                         reason: "insufficient bytes in Diameter AVP for Data payload",
@@ -1641,7 +1706,7 @@ impl<'a> GenericAvpRef<'a> {
                 // Validate length field (too small)
                 if unpadded_len < minimum_length {
                     return Err(ValidationError {
-                        layer: Diameter::name(),
+                        layer: DiamBaseRef::name(),
                         class: ValidationErrorClass::InsufficientBytes,
                         #[cfg(feature = "error_string")]
                         reason: "Diameter AVP Length field was too small for header",
@@ -1652,7 +1717,7 @@ impl<'a> GenericAvpRef<'a> {
                 for b in bytes.iter().take(len).skip(unpadded_len) {
                     if *b != 0 {
                         return Err(ValidationError {
-                            layer: Diameter::name(),
+                            layer: DiamBaseRef::name(),
                             class: ValidationErrorClass::UnusualPadding,
                             #[cfg(feature = "error_string")]
                             reason: "non-zero padding values found at end of Diameter AVP",
@@ -1662,7 +1727,7 @@ impl<'a> GenericAvpRef<'a> {
 
                 if len < bytes.len() {
                     Err(ValidationError {
-                        layer: Diameter::name(),
+                        layer: DiamBaseRef::name(),
                         class: ValidationErrorClass::ExcessBytes(bytes.len() - len),
                         #[cfg(feature = "error_string")]
                         reason: "extra bytes remain at end of Diameter AVP",
@@ -1672,7 +1737,7 @@ impl<'a> GenericAvpRef<'a> {
                 }
             }
             _ => Err(ValidationError {
-                layer: Diameter::name(),
+                layer: DiamBaseRef::name(),
                 class: ValidationErrorClass::InsufficientBytes,
                 #[cfg(feature = "error_string")]
                 reason: "insufficient bytes in Diameter AVP for header",

--- a/pkts/src/layers/example.rs
+++ b/pkts/src/layers/example.rs
@@ -8,11 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use pkts_macros::{Layer, LayerRef, StatelessLayer};
+#[cfg(feature = "alloc")]
+use pkts_macros::Layer;
+use pkts_macros::{LayerRef, StatelessLayer};
 
 use crate::error::*;
 use crate::layers::dev_traits::*;
 use crate::layers::traits::*;
+#[cfg(feature = "alloc")]
 use crate::writer::PacketWriter;
 
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
@@ -23,12 +26,15 @@ use alloc::vec::Vec;
 #[derive(Clone, Debug, Layer, StatelessLayer)]
 #[metadata_type(ExampleMetadata)]
 #[ref_type(ExampleRef)]
+#[cfg(feature = "alloc")]
 pub struct Example {}
 
+#[cfg(feature = "alloc")]
 impl Example {}
 
 #[doc(hidden)]
 #[allow(unused_variables)]
+#[cfg(feature = "alloc")]
 impl FromBytesCurrent for Example {
     fn payload_from_bytes_unchecked_default(&mut self, bytes: &[u8]) {
         todo!()
@@ -39,6 +45,7 @@ impl FromBytesCurrent for Example {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl LayerLength for Example {
     fn len(&self) -> usize {
         todo!()
@@ -46,6 +53,7 @@ impl LayerLength for Example {
 }
 
 #[allow(unused_variables)]
+#[cfg(feature = "alloc")]
 impl LayerObject for Example {
     fn can_add_payload_default(&self, payload: &dyn LayerObject) -> bool {
         todo!()
@@ -71,6 +79,7 @@ impl LayerObject for Example {
 }
 
 #[allow(unused_variables)]
+#[cfg(feature = "alloc")]
 impl ToBytes for Example {
     fn to_bytes_checksummed(
         &self,

--- a/pkts/src/layers/mysql.rs
+++ b/pkts/src/layers/mysql.rs
@@ -12,16 +12,21 @@
 //!
 
 use core::cmp::Ordering;
-use core::convert::{TryFrom, TryInto};
+#[cfg(feature = "alloc")]
 use core::slice;
 
+#[cfg(feature = "alloc")]
 use super::Raw;
+use super::RawRef;
 use crate::error::*;
 use crate::layers::dev_traits::*;
 use crate::layers::traits::*;
+#[cfg(feature = "alloc")]
 use crate::writer::PacketWriter;
 
-use pkts_macros::{Layer, LayerRef, StatelessLayer};
+#[cfg(feature = "alloc")]
+use pkts_macros::Layer;
+use pkts_macros::{LayerRef, StatelessLayer};
 
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 use alloc::boxed::Box;
@@ -42,11 +47,13 @@ use alloc::vec::Vec;
 #[derive(Clone, Debug, Layer, StatelessLayer)]
 #[metadata_type(MysqlPacketMetadata)]
 #[ref_type(MysqlPacketRef)]
+#[cfg(feature = "alloc")]
 pub struct MysqlPacket {
     sequence_id: u8,
     payload: Option<Box<dyn LayerObject>>,
 }
 
+#[cfg(feature = "alloc")]
 impl MysqlPacket {
     #[inline]
     pub fn sequence_id(&self) -> u8 {
@@ -65,6 +72,7 @@ impl MysqlPacket {
 }
 
 #[doc(hidden)]
+#[cfg(feature = "alloc")]
 impl FromBytesCurrent for MysqlPacket {
     #[inline]
     fn payload_from_bytes_unchecked_default(&mut self, bytes: &[u8]) {
@@ -82,6 +90,7 @@ impl FromBytesCurrent for MysqlPacket {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl LayerLength for MysqlPacket {
     #[inline]
     fn len(&self) -> usize {
@@ -89,6 +98,7 @@ impl LayerLength for MysqlPacket {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl LayerObject for MysqlPacket {
     #[inline]
     fn can_add_payload_default(&self, _payload: &dyn LayerObject) -> bool {
@@ -128,6 +138,7 @@ impl LayerObject for MysqlPacket {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl ToBytes for MysqlPacket {
     fn to_bytes_checksummed(
         &self,
@@ -189,7 +200,7 @@ impl<'a> LayerOffset for MysqlPacketRef<'a> {
             return None;
         }
 
-        if layer_type == Raw::layer_id() {
+        if layer_type == RawRef::layer_id() {
             Some(4)
         } else {
             None
@@ -201,7 +212,7 @@ impl<'a> Validate for MysqlPacketRef<'a> {
     fn validate_current_layer(curr_layer: &[u8]) -> Result<(), ValidationError> {
         if curr_layer.len() < 4 {
             return Err(ValidationError {
-                layer: MysqlPacket::name(),
+                layer: Self::name(),
                 class: ValidationErrorClass::InsufficientBytes,
                 #[cfg(feature = "error_string")]
                 reason: "insufficient bytes for MySQL Packet header (4 bytes required)",
@@ -214,13 +225,13 @@ impl<'a> Validate for MysqlPacketRef<'a> {
 
         match curr_layer[4..].len().cmp(&payload_len) {
             Ordering::Less => Err(ValidationError {
-                layer: MysqlPacket::name(),
+                layer: Self::name(),
                 class: ValidationErrorClass::InsufficientBytes,
                 #[cfg(feature = "error_string")]
                 reason: "insufficient bytes for packet length advertised by MySQL header",
             }),
             Ordering::Greater => Err(ValidationError {
-                layer: MysqlPacket::name(),
+                layer: Self::name(),
                 class: ValidationErrorClass::ExcessBytes(curr_layer[4..].len() - payload_len),
                 #[cfg(feature = "error_string")]
                 reason:
@@ -240,17 +251,20 @@ impl<'a> Validate for MysqlPacketRef<'a> {
 #[derive(Clone, Debug, Layer)]
 #[metadata_type(MysqlClientMetadata)]
 #[ref_type(MysqlClientRef)]
+#[cfg(feature = "alloc")]
 pub struct MysqlClient {
     pub sequence_id: u8,
     pub payload: Option<Box<dyn LayerObject>>,
 }
 
+#[cfg(feature = "alloc")]
 impl LayerLength for MysqlClient {
     fn len(&self) -> usize {
         todo!()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl LayerObject for MysqlClient {
     #[inline]
     fn can_add_payload_default(&self, _payload: &dyn LayerObject) -> bool {
@@ -289,6 +303,7 @@ impl LayerObject for MysqlClient {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl ToBytes for MysqlClient {
     fn to_bytes_checksummed(
         &self,
@@ -300,6 +315,7 @@ impl ToBytes for MysqlClient {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> From<&MysqlClientRef<'a>> for MysqlClient {
     fn from(_value: &MysqlClientRef<'a>) -> Self {
         todo!()

--- a/pkts/src/layers/psql.rs
+++ b/pkts/src/layers/psql.rs
@@ -11,7 +11,6 @@
 //! Protocol layers used for communication between PostgreSQL clients and databases.
 //!
 
-use core::convert::{TryFrom, TryInto};
 use core::ffi::CStr;
 use core::iter::Iterator;
 use core::{cmp, str};
@@ -20,7 +19,9 @@ use std::collections::BTreeMap;
 #[cfg(feature = "std")]
 use std::ffi::CString;
 
-use pkts_macros::{Layer, LayerRef, StatelessLayer};
+#[cfg(feature = "alloc")]
+use pkts_macros::Layer;
+use pkts_macros::{LayerRef, StatelessLayer};
 
 use crate::layers::dev_traits::*;
 use crate::layers::traits::*;
@@ -38,6 +39,7 @@ use alloc::string::String;
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 use alloc::vec::Vec;
 
+#[cfg(feature = "alloc")]
 const CLIENT_MSG_BIND: u8 = b'B';
 const CLIENT_MSG_STARTUP: u8 = 0x00;
 const CLIENT_MSG_CLOSE: u8 = b'C';
@@ -45,18 +47,28 @@ const CLIENT_MSG_COPY_DATA: u8 = b'd';
 const CLIENT_MSG_COPY_DONE: u8 = b'c';
 const CLIENT_MSG_COPY_FAIL: u8 = b'f';
 const CLIENT_MSG_DESCRIBE: u8 = b'D';
+#[cfg(feature = "alloc")]
 const CLIENT_MSG_EXECUTE: u8 = b'E';
 const CLIENT_MSG_FLUSH: u8 = b'H';
+#[cfg(feature = "alloc")]
 const CLIENT_MSG_FN_CALL: u8 = b'F';
+#[cfg(feature = "alloc")]
 const CLIENT_MSG_AUTH_RESP: u8 = b'p';
+#[cfg(feature = "alloc")]
 const CLIENT_MSG_PARSE: u8 = b'P';
+#[cfg(feature = "alloc")]
 const CLIENT_MSG_QUERY: u8 = b'Q';
+#[cfg(feature = "alloc")]
 const CLIENT_MSG_SYNC: u8 = b'S';
+#[cfg(feature = "alloc")]
 const CLIENT_MSG_TERMINATE: u8 = b'X';
 
+#[cfg(feature = "alloc")]
 const CLIENT_STARTUP_V3_0: i32 = 0x0003_0000;
 const CLIENT_STARTUP_CANCEL_REQ: i32 = 0x1234_5678;
+#[cfg(feature = "alloc")]
 const CLIENT_STARTUP_SSL_REQ: i32 = 0x1234_5679;
+#[cfg(feature = "alloc")]
 const CLIENT_STARTUP_GSS_ENC_REQ: i32 = 0x1234_5680;
 
 /*
@@ -113,10 +125,12 @@ const SERVER_AUTH_SASL_FINAL: i32 = 12;
 #[derive(Clone, Debug, Layer, StatelessLayer)]
 #[metadata_type(PsqlClientMetadata)]
 #[ref_type(PsqlClientRef)]
+#[cfg(feature = "alloc")]
 pub struct PsqlClient {
     packet: ClientMessage,
 }
 
+#[cfg(feature = "alloc")]
 impl PsqlClient {
     #[inline]
     pub fn message(&self) -> &ClientMessage {
@@ -129,6 +143,7 @@ impl PsqlClient {
     }
 }
 
+#[cfg(feature = "alloc")]
 #[doc(hidden)]
 impl FromBytesCurrent for PsqlClient {
     #[inline]
@@ -139,6 +154,7 @@ impl FromBytesCurrent for PsqlClient {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl LayerLength for PsqlClient {
     #[inline]
     fn len(&self) -> usize {
@@ -146,6 +162,7 @@ impl LayerLength for PsqlClient {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl LayerObject for PsqlClient {
     #[inline]
     fn can_add_payload_default(&self, _payload: &dyn LayerObject) -> bool {
@@ -193,6 +210,7 @@ impl LayerObject for PsqlClient {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl ToBytes for PsqlClient {
     fn to_bytes_checksummed(
         &self,
@@ -205,6 +223,7 @@ impl ToBytes for PsqlClient {
 }
 
 #[derive(Clone, Debug)]
+#[cfg(feature = "alloc")]
 pub enum ClientMessage {
     /// Encapsulates any of SASL, GSSAPI, SSPI and password response messages
     AuthDataResponse(AuthDataResponse),
@@ -269,6 +288,7 @@ pub enum ClientMessage {
     Terminate,
 }
 
+#[cfg(feature = "alloc")]
 impl ClientMessage {
     #[inline]
     pub fn msg_id(&self) -> u8 {
@@ -369,10 +389,12 @@ impl ClientMessage {
 }
 
 #[derive(Clone, Debug)]
+#[cfg(feature = "alloc")]
 pub struct AuthDataResponse {
     data: Vec<u8>,
 }
 
+#[cfg(feature = "alloc")]
 impl AuthDataResponse {
     #[inline]
     pub fn msg_id(&self) -> u8 {
@@ -460,10 +482,12 @@ impl CancelRequest {
 }
 
 #[derive(Clone, Debug)]
+#[cfg(feature = "alloc")]
 pub struct ClosePortal {
     portal_name: CString,
 }
 
+#[cfg(feature = "alloc")]
 impl ClosePortal {
     #[inline]
     pub fn msg_id(&self) -> u8 {
@@ -503,10 +527,12 @@ impl ClosePortal {
 }
 
 #[derive(Clone, Debug)]
+#[cfg(feature = "alloc")]
 pub struct ClosePrepared {
     stmt_name: CString,
 }
 
+#[cfg(feature = "alloc")]
 impl ClosePrepared {
     #[inline]
     pub fn msg_id(&self) -> u8 {
@@ -546,10 +572,12 @@ impl ClosePrepared {
 }
 
 #[derive(Clone, Debug)]
+#[cfg(feature = "alloc")]
 pub struct CopyData {
     data_stream: Vec<u8>,
 }
 
+#[cfg(feature = "alloc")]
 impl CopyData {
     #[inline]
     pub fn msg_id(&self) -> u8 {
@@ -583,10 +611,12 @@ impl CopyData {
 }
 
 #[derive(Clone, Debug)]
+#[cfg(feature = "alloc")]
 pub struct CopyFail {
     err_msg: CString,
 }
 
+#[cfg(feature = "alloc")]
 impl CopyFail {
     #[inline]
     pub fn msg_id(&self) -> u8 {
@@ -620,10 +650,12 @@ impl CopyFail {
 }
 
 #[derive(Clone, Debug)]
+#[cfg(feature = "alloc")]
 pub struct DescribePortal {
     portal_name: CString,
 }
 
+#[cfg(feature = "alloc")]
 impl DescribePortal {
     #[inline]
     pub fn msg_id(&self) -> u8 {
@@ -663,10 +695,12 @@ impl DescribePortal {
 }
 
 #[derive(Clone, Debug)]
+#[cfg(feature = "alloc")]
 pub struct DescribePrepared {
     stmt_name: CString,
 }
 
+#[cfg(feature = "alloc")]
 impl DescribePrepared {
     #[inline]
     pub fn msg_id(&self) -> u8 {
@@ -706,11 +740,13 @@ impl DescribePrepared {
 }
 
 #[derive(Clone, Debug)]
+#[cfg(feature = "alloc")]
 pub struct Execute {
     portal_name: CString,  // empty string means unnamed portal
     max_rows: Option<i32>, // None corresponds to 0
 }
 
+#[cfg(feature = "alloc")]
 impl Execute {
     #[inline]
     pub fn msg_id(&self) -> u8 {
@@ -755,12 +791,14 @@ impl Execute {
 }
 
 #[derive(Clone, Debug)]
+#[cfg(feature = "alloc")]
 pub struct Parse {
     dst_stmt: CString,
     query: CString,
     type_ids: Vec<Option<i32>>,
 }
 
+#[cfg(feature = "alloc")]
 impl Parse {
     #[inline]
     pub fn msg_id(&self) -> u8 {
@@ -823,10 +861,12 @@ impl Parse {
 }
 
 #[derive(Clone, Debug)]
+#[cfg(feature = "alloc")]
 pub struct Query {
     query: CString,
 }
 
+#[cfg(feature = "alloc")]
 impl Query {
     #[inline]
     pub fn msg_id(&self) -> u8 {
@@ -860,11 +900,13 @@ impl Query {
 }
 
 #[derive(Clone, Debug)]
+#[cfg(feature = "alloc")]
 pub struct StartupMessage {
     //    minor_version: u16,
     params: Vec<(CString, CString)>,
 }
 
+#[cfg(feature = "alloc")]
 impl StartupMessage {
     #[inline]
     pub fn msg_id(&self) -> u8 {
@@ -922,6 +964,7 @@ impl StartupMessage {
 }
 
 #[derive(Clone, Debug)]
+#[cfg(feature = "alloc")]
 pub struct Bind {
     dst_portal: CString,          // empty indicates unnamed portal
     src_prepared: CString,        // empty indicates the unnamed prepared statement
@@ -930,6 +973,7 @@ pub struct Bind {
     results_fmt: Vec<FormatCode>,
 }
 
+#[cfg(feature = "alloc")]
 impl Bind {
     #[inline]
     pub fn msg_id(&self) -> u8 {
@@ -1028,6 +1072,7 @@ impl Bind {
 }
 
 #[derive(Clone, Debug)]
+#[cfg(feature = "alloc")]
 pub struct FunctionCall {
     function_id: i32,
     args_fmt: Vec<FormatCode>,
@@ -1035,6 +1080,7 @@ pub struct FunctionCall {
     result_fmt: FormatCode,
 }
 
+#[cfg(feature = "alloc")]
 impl FunctionCall {
     #[inline]
     pub fn msg_id(&self) -> u8 {
@@ -1450,7 +1496,7 @@ impl<'a> CancelRequestRef<'a> {
         let (msg_length, cancel_req_code) = match (utils::get_array(bytes, 0), utils::get_array(bytes, 4)) {
             (Some(m), Some(c)) if bytes.len() >= 16 => (i32::from_be_bytes(*m), i32::from_be_bytes(*c)),
             _ => return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InsufficientBytes,
                 #[cfg(feature = "error_string")]
                 reason: "insufficient bytes in PsqlClient Cancel Request packet to extract Message fields",
@@ -1459,7 +1505,7 @@ impl<'a> CancelRequestRef<'a> {
 
         if msg_length != 16 {
             return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason: "Length field in PsqlClient Cancel Request packet did not match expected (must be equal to 16)",
@@ -1468,7 +1514,7 @@ impl<'a> CancelRequestRef<'a> {
 
         if cancel_req_code != CLIENT_STARTUP_CANCEL_REQ {
             return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason: "Cancel Request Code field in PsqlClient Cancel Request packet did not match expected (must be equal to 0x12345678)",
@@ -1477,7 +1523,7 @@ impl<'a> CancelRequestRef<'a> {
 
         if bytes.len() > 16 {
             Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::ExcessBytes(bytes.len() - 16),
                 #[cfg(feature = "error_string")]
                 reason: "extra bytes remained at end of PsqlClient Cancel Request packet",
@@ -1538,7 +1584,7 @@ impl<'a> ClosePortalRef<'a> {
         ) {
             (Some(m), Some(c), Some(t)) => (*m, i32::from_be_bytes(*c), *t),
             _ => return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InsufficientBytes,
                 #[cfg(feature = "error_string")]
                 reason:
@@ -1556,7 +1602,7 @@ impl<'a> ClosePortalRef<'a> {
             Some(t) => t,
             None => {
                 return Err(ValidationError {
-                    layer: PsqlClient::name(),
+                    layer: PsqlClientRef::name(),
                     class: ValidationErrorClass::InsufficientBytes,
                     #[cfg(feature = "error_string")]
                     reason:
@@ -1567,7 +1613,7 @@ impl<'a> ClosePortalRef<'a> {
 
         if msg_type != CLIENT_MSG_CLOSE {
             return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason:
@@ -1577,7 +1623,7 @@ impl<'a> ClosePortalRef<'a> {
 
         if msg_length < 7 {
             return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason:
@@ -1587,7 +1633,7 @@ impl<'a> ClosePortalRef<'a> {
 
         if close_type != b'P' {
             return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason: "wrong Close Type field in PsqlClient Close Portal packet (expected 0x50)",
@@ -1597,14 +1643,14 @@ impl<'a> ClosePortalRef<'a> {
         match str::from_utf8(portal_name_bytes) {
             Ok(s) => if s.find('\x00').is_some() {
                 return Err(ValidationError {
-                    layer: PsqlClient::name(),
+                    layer: PsqlClientRef::name(),
                     class: ValidationErrorClass::InvalidValue,
                     #[cfg(feature = "error_string")]
                     reason: "null character found before end of string in PsqlClient Close Portal packet Portal Name field",
                 })
             },
             Err(_) => return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason: "invalid UTF-8 character found in PsqlClient Close Portal packet Portal Name field",
@@ -1613,7 +1659,7 @@ impl<'a> ClosePortalRef<'a> {
 
         if *null_term != 0 {
             return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason: "missing null terminating byte at end of PsqlClient Close Portal packet Portal Name field",
@@ -1622,7 +1668,7 @@ impl<'a> ClosePortalRef<'a> {
 
         if bytes.len() > msg_length {
             Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::ExcessBytes(bytes.len() - msg_length),
                 #[cfg(feature = "error_string")]
                 reason: "trailing bytes found at end of PsqlClient Close Portal packet",
@@ -1679,7 +1725,7 @@ impl<'a> ClosePreparedRef<'a> {
         let (msg_type, msg_length, close_type) = match (bytes.first(), utils::get_array(bytes, 1), bytes.get(6)) {
             (Some(m), Some(c), Some(t)) => (*m, i32::from_be_bytes(*c), *t),
             _ => return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InsufficientBytes,
                 #[cfg(feature = "error_string")]
                 reason: "insufficient bytes in PsqlClient Close Prepared Statement packet to extract message fields",
@@ -1691,7 +1737,7 @@ impl<'a> ClosePreparedRef<'a> {
         let (null_term, portal_name_bytes) = match bytes.get(6..cmp::max(7, msg_length)).and_then(|b| b.split_last()) { // 1 for msg_type + 4 for msg_len + 1 for close_type + 1 for minimum size of string (null terminator)
             Some(t) => t,
             None => return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InsufficientBytes,
                 #[cfg(feature = "error_string")]
                 reason: "insufficient bytes in PsqlClient Close Prepared Statement packet for Prepared Statement Name field",
@@ -1700,7 +1746,7 @@ impl<'a> ClosePreparedRef<'a> {
 
         if msg_type != CLIENT_MSG_CLOSE {
             return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason: "wrong Message Type field in PsqlClient Close Prepared Statement packet (expected 0x43)",
@@ -1709,7 +1755,7 @@ impl<'a> ClosePreparedRef<'a> {
 
         if msg_length < 7 {
             return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason: "invalid Length field in PsqlClient Close Prepared Statement packet (must be at least 7)",
@@ -1718,7 +1764,7 @@ impl<'a> ClosePreparedRef<'a> {
 
         if close_type != b'S' {
             return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason: "wrong Close Type field in PsqlClient Close Prepared Statement packet (expected 0x53)",
@@ -1728,14 +1774,14 @@ impl<'a> ClosePreparedRef<'a> {
         match str::from_utf8(portal_name_bytes) {
             Ok(s) => if s.find('\x00').is_some() {
                 return Err(ValidationError {
-                    layer: PsqlClient::name(),
+                    layer: PsqlClientRef::name(),
                     class: ValidationErrorClass::InvalidValue,
                     #[cfg(feature = "error_string")]
                     reason: "null character found before end of string in PsqlClient Close Prepared Statement packet Prepared Statement Name field",
                 })
             },
             Err(_) => return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason: "invalid UTF-8 character found in PsqlClient Close Prepared Statement packet Prepared Statement Name field",
@@ -1744,7 +1790,7 @@ impl<'a> ClosePreparedRef<'a> {
 
         if *null_term != 0 {
             return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason: "missing null terminating byte at end of PsqlClient Close Prepared Statement packet Prepared Statement Name field",
@@ -1753,7 +1799,7 @@ impl<'a> ClosePreparedRef<'a> {
 
         if bytes.len() > msg_length {
             Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::ExcessBytes(bytes.len() - msg_length),
                 #[cfg(feature = "error_string")]
                 reason: "trailing bytes found at end of PsqlClient Close Prepared Statement packet",
@@ -1806,7 +1852,7 @@ impl<'a> CopyDataRef<'a> {
         let (msg_type, msg_length) = match (bytes.first(), utils::get_array(bytes, 1)) {
             (Some(m), Some(c)) => (*m, i32::from_be_bytes(*c)),
             _ => return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InsufficientBytes,
                 #[cfg(feature = "error_string")]
                 reason:
@@ -1817,7 +1863,7 @@ impl<'a> CopyDataRef<'a> {
         let msg_length = cmp::max(5, msg_length) as usize;
         if bytes.len() < msg_length {
             return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InsufficientBytes,
                 #[cfg(feature = "error_string")]
                 reason:
@@ -1827,7 +1873,7 @@ impl<'a> CopyDataRef<'a> {
 
         if msg_type != CLIENT_MSG_COPY_DATA {
             return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason: "wrong Message Type field in PsqlClient Copy Data packet (expected 0x43)",
@@ -1836,7 +1882,7 @@ impl<'a> CopyDataRef<'a> {
 
         if msg_length < 5 {
             return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InsufficientBytes,
                 #[cfg(feature = "error_string")]
                 reason: "invalid Message Length field in PsqlClient Copy Data packet (too short--must be >= 5)",
@@ -1845,7 +1891,7 @@ impl<'a> CopyDataRef<'a> {
 
         if bytes.len() > msg_length {
             Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::ExcessBytes(bytes.len() - msg_length),
                 #[cfg(feature = "error_string")]
                 reason: "trailing bytes found at end of PsqlClient Copy Data packet",
@@ -1892,7 +1938,7 @@ impl<'a> CopyDoneRef<'a> {
         let (msg_type, msg_length) = match (bytes.first(), utils::get_array(bytes, 1)) {
             (Some(m), Some(c)) => (*m, i32::from_be_bytes(*c)),
             _ => return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InsufficientBytes,
                 #[cfg(feature = "error_string")]
                 reason: "insufficient bytes in PsqlClient Copy Done packet to extract message header fields",
@@ -1901,7 +1947,7 @@ impl<'a> CopyDoneRef<'a> {
 
         if msg_type != CLIENT_MSG_COPY_DONE {
             return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason: "wrong Message Type field in PsqlClient Copy Done packet (expected 0x63)",
@@ -1910,7 +1956,7 @@ impl<'a> CopyDoneRef<'a> {
 
         if msg_length != 5 {
             return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InsufficientBytes,
                 #[cfg(feature = "error_string")]
                 reason: "invalid Message Length field in PsqlClient Copy Done packet (must be equal to 5)",
@@ -1919,7 +1965,7 @@ impl<'a> CopyDoneRef<'a> {
 
         if bytes.len() > 5 {
             Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::ExcessBytes(bytes.len() - 5),
                 #[cfg(feature = "error_string")]
                 reason: "trailing bytes found at end of PsqlClient Copy Done packet",
@@ -1971,7 +2017,7 @@ impl<'a> CopyFailRef<'a> {
         let (msg_type, msg_length) = match (bytes.first(), utils::get_array(bytes, 1)) {
             (Some(m), Some(c)) => (*m, i32::from_be_bytes(*c)),
             _ => return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InsufficientBytes,
                 #[cfg(feature = "error_string")]
                 reason:
@@ -1989,7 +2035,7 @@ impl<'a> CopyFailRef<'a> {
                 // 1 for msg_type + 4 for msg_len + 1 for minimum size of string (null terminator)
                 Some(t) => t,
                 None => return Err(ValidationError {
-                    layer: PsqlClient::name(),
+                    layer: PsqlClientRef::name(),
                     class: ValidationErrorClass::InsufficientBytes,
                     #[cfg(feature = "error_string")]
                     reason:
@@ -1999,7 +2045,7 @@ impl<'a> CopyFailRef<'a> {
 
         if msg_type != CLIENT_MSG_COPY_FAIL {
             return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason: "wrong Message Type field in PsqlClient Copy Fail packet (expected 0x66)",
@@ -2008,7 +2054,7 @@ impl<'a> CopyFailRef<'a> {
 
         if msg_length < 6 {
             return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason: "invalid Length field in PsqlClient Copy Fail packet (must be at least 6)",
@@ -2018,14 +2064,14 @@ impl<'a> CopyFailRef<'a> {
         match str::from_utf8(portal_name_bytes) {
             Ok(s) => if s.find('\x00').is_some() {
                 return Err(ValidationError {
-                    layer: PsqlClient::name(),
+                    layer: PsqlClientRef::name(),
                     class: ValidationErrorClass::InvalidValue,
                     #[cfg(feature = "error_string")]
                     reason: "null character found before end of string in PsqlClient Copy Fail packet Error Message field",
                 })
             },
             Err(_) => return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason: "invalid UTF-8 character found in PsqlClient Copy Fail packet Error Message field",
@@ -2034,7 +2080,7 @@ impl<'a> CopyFailRef<'a> {
 
         if *null_term != 0 {
             return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason: "missing null terminating byte at end of PsqlClient Copy Fail packet Prepared Statement Name field",
@@ -2043,7 +2089,7 @@ impl<'a> CopyFailRef<'a> {
 
         if bytes.len() > msg_length {
             Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::ExcessBytes(bytes.len() - msg_length),
                 #[cfg(feature = "error_string")]
                 reason: "trailing bytes found at end of PsqlClient Copy Fail packet",
@@ -2100,7 +2146,7 @@ impl<'a> DescribePortalRef<'a> {
         let (msg_type, msg_length, describe_type) = match (bytes.first(), utils::get_array(bytes, 1), bytes.get(6)) {
             (Some(m), Some(c), Some(t)) => (*m, i32::from_be_bytes(*c), *t),
             _ => return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InsufficientBytes,
                 #[cfg(feature = "error_string")]
                 reason: "insufficient bytes in PsqlClient Describe Portal packet to extract message fields",
@@ -2116,7 +2162,7 @@ impl<'a> DescribePortalRef<'a> {
             // 1 for msg_type + 4 for msg_len + 1 for close_type + 1 for minimum size of string (null terminator)
             Some(t) => t,
             None => return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InsufficientBytes,
                 #[cfg(feature = "error_string")]
                 reason:
@@ -2126,7 +2172,7 @@ impl<'a> DescribePortalRef<'a> {
 
         if msg_type != CLIENT_MSG_DESCRIBE {
             return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason:
@@ -2136,7 +2182,7 @@ impl<'a> DescribePortalRef<'a> {
 
         if msg_length < 7 {
             return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason:
@@ -2146,7 +2192,7 @@ impl<'a> DescribePortalRef<'a> {
 
         if describe_type != b'P' {
             return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason:
@@ -2157,14 +2203,14 @@ impl<'a> DescribePortalRef<'a> {
         match str::from_utf8(portal_name_bytes) {
             Ok(s) => if s.find('\x00').is_some() {
                 return Err(ValidationError {
-                    layer: PsqlClient::name(),
+                    layer: PsqlClientRef::name(),
                     class: ValidationErrorClass::InvalidValue,
                     #[cfg(feature = "error_string")]
                     reason: "null character found before end of string in PsqlClient Describe Portal packet Portal Name field",
                 })
             },
             Err(_) => return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason: "invalid UTF-8 character found in PsqlClient Describe Portal packet Portal Name field",
@@ -2173,7 +2219,7 @@ impl<'a> DescribePortalRef<'a> {
 
         if *null_term != 0 {
             return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason: "missing null terminating byte at end of PsqlClient Describe Portal packet Portal Name field",
@@ -2182,7 +2228,7 @@ impl<'a> DescribePortalRef<'a> {
 
         if bytes.len() > msg_length {
             Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::ExcessBytes(bytes.len() - msg_length),
                 #[cfg(feature = "error_string")]
                 reason: "trailing bytes found at end of PsqlClient Describe Portal packet",
@@ -2239,7 +2285,7 @@ impl<'a> DescribePreparedRef<'a> {
         let (msg_type, msg_length, describe_type) = match (bytes.first(), utils::get_array(bytes, 1), bytes.get(6)) {
             (Some(m), Some(c), Some(t)) => (*m, i32::from_be_bytes(*c), *t),
             _ => return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InsufficientBytes,
                 #[cfg(feature = "error_string")]
                 reason: "insufficient bytes in PsqlClient Describe Prepared Statement packet to extract message fields",
@@ -2251,7 +2297,7 @@ impl<'a> DescribePreparedRef<'a> {
         let (null_term, portal_name_bytes) = match bytes.get(6..cmp::max(7, msg_length)).and_then(|b| b.split_last()) { // 1 for msg_type + 4 for msg_len + 1 for close_type + 1 for minimum size of string (null terminator)
             Some(t) => t,
             None => return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InsufficientBytes,
                 #[cfg(feature = "error_string")]
                 reason: "insufficient bytes in PsqlClient Describe Prepared Statement packet for Prepared Statement Name field",
@@ -2260,7 +2306,7 @@ impl<'a> DescribePreparedRef<'a> {
 
         if msg_type != CLIENT_MSG_DESCRIBE {
             return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason: "wrong Message Type field in PsqlClient Describe Prepared Statement packet (expected 0x44)",
@@ -2269,7 +2315,7 @@ impl<'a> DescribePreparedRef<'a> {
 
         if msg_length < 7 {
             return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason: "invalid Length field in PsqlClient Describe Prepared Statement packet (must be at least 7)",
@@ -2278,7 +2324,7 @@ impl<'a> DescribePreparedRef<'a> {
 
         if describe_type != b'S' {
             return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason: "wrong Describe Type field in PsqlClient Describe Prepared Statement packet (expected 0x53)",
@@ -2288,14 +2334,14 @@ impl<'a> DescribePreparedRef<'a> {
         match str::from_utf8(portal_name_bytes) {
             Ok(s) => if s.find('\x00').is_some() {
                 return Err(ValidationError {
-                    layer: PsqlClient::name(),
+                    layer: PsqlClientRef::name(),
                     class: ValidationErrorClass::InvalidValue,
                     #[cfg(feature = "error_string")]
                     reason: "null character found before end of string in PsqlClient Describe Prepared Statement packet Prepared Statement Name field",
                 })
             },
             Err(_) => return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason: "invalid UTF-8 character found in PsqlClient Describe Prepared Statement packet Prepared Statement Name field",
@@ -2304,7 +2350,7 @@ impl<'a> DescribePreparedRef<'a> {
 
         if *null_term != 0 {
             return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason: "missing null terminating byte at end of PsqlClient Close Prepared Statement packet Prepared Statement Name field",
@@ -2313,7 +2359,7 @@ impl<'a> DescribePreparedRef<'a> {
 
         if bytes.len() > msg_length {
             Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::ExcessBytes(bytes.len() - msg_length),
                 #[cfg(feature = "error_string")]
                 reason: "trailing bytes found at end of PsqlClient Close Prepared Statement packet",
@@ -2377,7 +2423,7 @@ impl<'a> ExecuteRef<'a> {
         let (msg_type, msg_length) = match (bytes.first(), utils::get_array(bytes, 1)) {
             (Some(m), Some(c)) => (*m, i32::from_be_bytes(*c)),
             _ => return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InsufficientBytes,
                 #[cfg(feature = "error_string")]
                 reason: "insufficient bytes in PsqlClient Execute packet to extract message header fields",
@@ -2390,7 +2436,7 @@ impl<'a> ExecuteRef<'a> {
             Some(r) => r,
             None => {
                 return Err(ValidationError {
-                    layer: PsqlClient::name(),
+                    layer: PsqlClientRef::name(),
                     class: ValidationErrorClass::InsufficientBytes,
                     #[cfg(feature = "error_string")]
                     reason: "insufficient bytes in PsqlClient Execute packet for Portal Name field",
@@ -2401,7 +2447,7 @@ impl<'a> ExecuteRef<'a> {
         let (portal_name_bytes, _max_rows_bytes) = match utils::split_delim(rem, 0x00) {
             Some(t) => t,
             None => return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InsufficientBytes,
                 #[cfg(feature = "error_string")]
                 reason: "missing null terminating byte in PsqlClient Execute packet for Portal Name field"
@@ -2410,7 +2456,7 @@ impl<'a> ExecuteRef<'a> {
 
         if msg_type != CLIENT_MSG_DESCRIBE {
             return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason: "wrong Message Type field in PsqlClient Describe Prepared Statement packet (expected 0x44)",
@@ -2419,7 +2465,7 @@ impl<'a> ExecuteRef<'a> {
 
         if msg_length < 7 {
             return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason: "invalid Length field in PsqlClient Describe Prepared Statement packet (must be at least 7)",
@@ -2429,14 +2475,14 @@ impl<'a> ExecuteRef<'a> {
         match str::from_utf8(portal_name_bytes) {
             Ok(s) => if s.find('\x00').is_some() {
                 return Err(ValidationError {
-                    layer: PsqlClient::name(),
+                    layer: PsqlClientRef::name(),
                     class: ValidationErrorClass::InvalidValue,
                     #[cfg(feature = "error_string")]
                     reason: "null character found before end of string in PsqlClient Describe Prepared Statement packet Prepared Statement Name field",
                 })
             },
             Err(_) => return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason: "invalid UTF-8 character found in PsqlClient Describe Prepared Statement packet Prepared Statement Name field",
@@ -2445,7 +2491,7 @@ impl<'a> ExecuteRef<'a> {
 
         if bytes.len() > msg_length {
             Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::ExcessBytes(bytes.len() - msg_length),
                 #[cfg(feature = "error_string")]
                 reason: "trailing bytes found at end of PsqlClient Close Prepared Statement packet",
@@ -2492,7 +2538,7 @@ impl<'a> FlushRef<'a> {
         let (msg_type, msg_length) = match (bytes.first(), utils::get_array(bytes, 1)) {
             (Some(m), Some(c)) => (*m, i32::from_be_bytes(*c)),
             _ => return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InsufficientBytes,
                 #[cfg(feature = "error_string")]
                 reason:
@@ -2502,7 +2548,7 @@ impl<'a> FlushRef<'a> {
 
         if msg_type != CLIENT_MSG_FLUSH {
             return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InvalidValue,
                 #[cfg(feature = "error_string")]
                 reason: "wrong Message Type field in PsqlClient Flush packet (expected 0x48)",
@@ -2511,7 +2557,7 @@ impl<'a> FlushRef<'a> {
 
         if msg_length != 5 {
             return Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::InsufficientBytes,
                 #[cfg(feature = "error_string")]
                 reason:
@@ -2521,7 +2567,7 @@ impl<'a> FlushRef<'a> {
 
         if bytes.len() > 5 {
             Err(ValidationError {
-                layer: PsqlClient::name(),
+                layer: PsqlClientRef::name(),
                 class: ValidationErrorClass::ExcessBytes(bytes.len() - 5),
                 #[cfg(feature = "error_string")]
                 reason: "trailing bytes found at end of PsqlClient Flush packet",
@@ -2534,7 +2580,7 @@ impl<'a> FlushRef<'a> {
 
 #[derive(Clone, Debug)]
 pub struct FunctionCallRef<'a> {
-    data: &'a [u8],
+    _data: &'a [u8],
     //    object_id: i32,
     //    arg_fmt: Vec<FormatCode>,
     //    arg_values: Vec<Option<Vec<u8>>>,
@@ -2543,12 +2589,12 @@ pub struct FunctionCallRef<'a> {
 
 #[derive(Clone, Debug)]
 pub struct GssEncRequestRef<'a> {
-    data: &'a [u8],
+    _data: &'a [u8],
 }
 
 #[derive(Clone, Debug)]
 pub struct ParseRef<'a> {
-    data: &'a [u8],
+    _data: &'a [u8],
     //    dst_stmt: String,
     //    query: String,
     //    type_ids: Vec<Option<i32>>,
@@ -2556,38 +2602,40 @@ pub struct ParseRef<'a> {
 
 #[derive(Clone, Debug)]
 pub struct QueryRef<'a> {
-    data: &'a [u8],
+    _data: &'a [u8],
     //    query: String,
 }
 
 #[derive(Clone, Debug)]
 pub struct SslRequestRef<'a> {
-    data: &'a [u8],
+    _data: &'a [u8],
 }
 
 #[derive(Clone, Debug)]
 pub struct StartupMessageRef<'a> {
-    data: &'a [u8],
+    _data: &'a [u8],
     //    params: Vec<(String, String)>,
 }
 
 #[derive(Clone, Debug)]
 pub struct SyncRef<'a> {
-    data: &'a [u8],
+    _data: &'a [u8],
 }
 
 #[derive(Clone, Debug)]
 pub struct TerminateRef<'a> {
-    data: &'a [u8],
+    _data: &'a [u8],
 }
 
 #[derive(Clone, Debug, Layer, StatelessLayer)]
 #[metadata_type(PsqlServerMetadata)]
 #[ref_type(PsqlServerRef)]
+#[cfg(feature = "alloc")]
 pub struct PsqlServer {
     packet: ServerMessage,
 }
 
+#[cfg(feature = "alloc")]
 impl PsqlServer {
     #[inline]
     pub fn message(&self) -> &ServerMessage {
@@ -2601,6 +2649,7 @@ impl PsqlServer {
 }
 
 #[doc(hidden)]
+#[cfg(feature = "alloc")]
 impl FromBytesCurrent for PsqlServer {
     fn payload_from_bytes_unchecked_default(&mut self, _bytes: &[u8]) {
         todo!()
@@ -2611,12 +2660,14 @@ impl FromBytesCurrent for PsqlServer {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl LayerLength for PsqlServer {
     fn len(&self) -> usize {
         todo!()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl LayerObject for PsqlServer {
     #[inline]
     fn can_add_payload_default(&self, _payload: &dyn LayerObject) -> bool {
@@ -2665,6 +2716,7 @@ impl LayerObject for PsqlServer {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl ToBytes for PsqlServer {
     fn to_bytes_checksummed(
         &self,
@@ -2677,6 +2729,7 @@ impl ToBytes for PsqlServer {
 }
 
 #[derive(Clone, Debug)]
+#[cfg(feature = "alloc")]
 pub enum ServerMessage {
     /// Indicates successful authentication
     AuthenticationOk,
@@ -2757,6 +2810,7 @@ pub enum ServerMessage {
 }
 
 #[derive(Clone, Debug)]
+#[cfg(feature = "alloc")]
 pub enum TransactionStatus {
     Idle,              // = 'I'
     Transaction,       // = 'T'
@@ -2764,14 +2818,15 @@ pub enum TransactionStatus {
 }
 
 #[derive(Clone, Debug)]
+#[cfg(feature = "alloc")]
 pub struct RowField {
-    name: String,
-    table_id: Option<i32>, // None = 0, which means field can't be identified as the column of a particular table
-    column_attr_num: Option<i16>, // None = 0, which means field can't be identified as the column of a particular table (thus no column attribute number)
-    data_id: i32,
-    size: Option<i16>, // None = negative val, which means variable length size
-    type_mod: i16,
-    fmt_code: i16, // enum (Text = 0, Binary = 1, Unknown = 2..)
+    _name: String,
+    _table_id: Option<i32>, // None = 0, which means field can't be identified as the column of a particular table
+    _column_attr_num: Option<i16>, // None = 0, which means field can't be identified as the column of a particular table (thus no column attribute number)
+    _data_id: i32,
+    _size: Option<i16>, // None = negative val, which means variable length size
+    _type_mod: i16,
+    _fmt_code: i16, // enum (Text = 0, Binary = 1, Unknown = 2..)
 }
 
 #[derive(Copy, Clone, Debug, LayerRef, StatelessLayer)]

--- a/pkts/src/lib.rs
+++ b/pkts/src/lib.rs
@@ -27,11 +27,13 @@ pub mod session;
 pub mod utils;
 pub mod writer;
 
+#[cfg(feature = "alloc")]
 mod private {
     pub trait Sealed {}
 }
 
 #[cfg(test)]
+#[cfg(feature = "alloc")]
 mod tests {
     use crate::layers::udp::*;
     use crate::sequence::ipv4::*;

--- a/pkts/src/prelude.rs
+++ b/pkts/src/prelude.rs
@@ -12,5 +12,9 @@ pub use pkts_common::{Buffer, BufferMut};
 
 pub use crate::error::{SerializationError, ValidationError, ValidationErrorClass};
 pub use crate::layers::traits::*;
-pub use crate::layers::{Raw, RawRef};
+#[cfg(feature = "alloc")]
+pub use crate::layers::Raw;
+pub use crate::layers::RawRef;
+
+#[cfg(feature = "alloc")]
 pub use crate::{parse_layers, parse_layers_unchecked};

--- a/pkts/src/sequence.rs
+++ b/pkts/src/sequence.rs
@@ -54,9 +54,11 @@
 pub mod ipv4;
 pub mod sctp;
 
+#[cfg(feature = "alloc")]
 use core::marker::PhantomData;
 
 use crate::error::*;
+#[cfg(feature = "alloc")]
 use crate::layers::dev_traits::*;
 use crate::layers::traits::*;
 
@@ -236,12 +238,14 @@ fn first_two_mut<T>(slice: &mut [T]) -> Option<(&mut T, &mut T)> {
     None
 }
 
+#[cfg(feature = "alloc")]
 struct SequenceLayer {
     layer: Box<dyn SequenceObject>,
     validation: ValidateFn,
     bytes: Option<Vec<u8>>,
 }
 
+#[cfg(feature = "alloc")]
 impl SequenceLayer {
     fn new(
         upper_layer: Box<dyn SequenceObject>,

--- a/pkts/src/sequence/ipv4.rs
+++ b/pkts/src/sequence/ipv4.rs
@@ -1,11 +1,6 @@
-use core::{cmp, mem};
-
-#[cfg(feature = "std")]
-use std::collections::{BTreeMap, VecDeque};
-
-use super::{PktFilterDynFn, Sequence, SequenceObject, UnboundedSequence};
-use crate::layers::ip::{Ipv4Flags, Ipv4Ref};
-use crate::layers::traits::*;
+use core::cmp;
+#[cfg(feature = "alloc")]
+use core::mem;
 
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 use alloc::boxed::Box;
@@ -13,6 +8,15 @@ use alloc::boxed::Box;
 use alloc::collections::{BTreeMap, VecDeque};
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 use alloc::vec::Vec;
+
+#[cfg(feature = "std")]
+use std::collections::{BTreeMap, VecDeque};
+
+#[cfg(feature = "alloc")]
+use super::UnboundedSequence;
+use super::{PktFilterDynFn, Sequence, SequenceObject};
+use crate::layers::ip::{Ipv4Flags, Ipv4Ref};
+use crate::layers::traits::*;
 
 /// A [`Sequence`] type that handles defragmentation of IPv4 packets.
 /// This Sequence guarantees that packets returned from it will be
@@ -464,7 +468,7 @@ impl<const FRAG_CNT: usize> Ipv4Fragments<FRAG_CNT> {
 }
 
 #[cfg(not(feature = "alloc"))]
-struct Ipv4Fragment {
+pub struct Ipv4Fragment {
     id: u16,
     buf: [u8; 65536],
     len: usize,

--- a/pkts/src/sequence/sctp.rs
+++ b/pkts/src/sequence/sctp.rs
@@ -1,14 +1,17 @@
 use core::cmp::Ordering;
 use core::convert::TryInto;
+#[cfg(feature = "alloc")]
 use core::mem;
 
 #[cfg(feature = "std")]
 use std::collections::{BTreeMap, VecDeque};
-#[cfg(feature = "std")]
-use std::iter::FromIterator;
 
+#[cfg(feature = "alloc")]
 use super::{PktFilterDynFn, Sequence, SequenceObject, UnboundedSequence};
-use crate::layers::sctp::{DataChunkFlags, SctpRef};
+use crate::layers::sctp::DataChunkFlags;
+#[cfg(feature = "alloc")]
+use crate::layers::sctp::SctpRef;
+#[cfg(feature = "alloc")]
 use crate::prelude::FromBytesRef;
 use crate::utils;
 
@@ -517,6 +520,7 @@ impl<'a> FragHeader<'a> {
     */
 }
 
+#[cfg(feature = "alloc")]
 struct SctpFragmentEntry {
     tsn: u32,
     flags: DataChunkFlags,

--- a/pkts/src/writer.rs
+++ b/pkts/src/writer.rs
@@ -1,5 +1,8 @@
+use core::cmp;
 use core::ops::{Index, Range, RangeFrom, RangeInclusive, RangeTo};
-use std::cmp;
+
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+use alloc::vec::Vec;
 
 use crate::layers::dev_traits::LayerName;
 use crate::prelude::*;
@@ -21,6 +24,7 @@ impl<'a, T: PacketWritable> PacketWriter<'a, T> {
 
     /// Constructs a new writer with errors reported as originating from `layer_naem`.
     #[inline]
+    #[cfg(feature = "alloc")]
     pub(crate) fn new_with_layer(writable: &'a mut T, layer_name: &'static str) -> Self {
         Self {
             writable,
@@ -155,6 +159,7 @@ pub trait PacketWritable:
     fn truncate(&mut self, pos: usize) -> Result<(), IndexedWriteError>;
 }
 
+#[cfg(feature = "alloc")]
 impl PacketWritable for Vec<u8> {
     #[inline]
     fn write_slice(&mut self, data: &[u8]) -> Result<(), IndexedWriteError> {


### PR DESCRIPTION
Currently, CI only tests default features. This PR adds testing for no default features, `alloc` only, and a suite of other important combinations. It also fixes a myriad of build errors that cropped up with no-std targets.