### PR TITLE
Fix bug in UDP validation routine

### DIFF
--- a/pkts/src/layers/udp.rs
+++ b/pkts/src/layers/udp.rs
@@ -417,7 +417,7 @@ impl Validate for UdpRef<'_> {
     #[inline]
     fn validate_payload_default(curr_layer: &[u8]) -> Result<(), ValidationError> {
         // We always consider the next layer after UDP to be `Raw`
-        Self::validate(&curr_layer[8..])
+        RawRef::validate(&curr_layer[8..])
     }
 }
 


### PR DESCRIPTION
The `Udp` layer accidentally validates its payload as if it is a `Udp` layer, when it should validate as if it is a `Raw` layer.